### PR TITLE
Extend IoC service in register(), not in boot()

### DIFF
--- a/src/ConfiguresQueue.php
+++ b/src/ConfiguresQueue.php
@@ -3,6 +3,8 @@
 namespace Laravel\Vapor;
 
 use Laravel\Vapor\Queue\VaporWorker;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Vapor\Queue\VaporConnector;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 
 trait ConfiguresQueue
@@ -14,6 +16,12 @@ trait ConfiguresQueue
      */
     protected function ensureQueueIsConfigured()
     {
+        $this->app->resolving('queue', function ($queue) {
+            $queue->extend('sqs', function () {
+                return new VaporConnector;
+            });
+        });
+        
         if ($this->app->bound('queue.vaporWorker')) {
             return;
         }

--- a/src/VaporServiceProvider.php
+++ b/src/VaporServiceProvider.php
@@ -2,11 +2,9 @@
 
 namespace Laravel\Vapor;
 
-use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
-use Laravel\Vapor\Queue\VaporConnector;
 use Laravel\Vapor\Console\Commands\VaporWorkCommand;
 use Laravel\Vapor\Http\Controllers\SignedStorageUrlController;
 
@@ -26,28 +24,6 @@ class VaporServiceProvider extends ServiceProvider
         if (($_ENV['VAPOR_SERVERLESS_DB'] ?? null) === 'true') {
             Schema::defaultStringLength(191);
         }
-
-        if ($this->app->resolved('queue')) {
-            call_user_func($this->queueExtender());
-        } else {
-            $this->app->afterResolving(
-                'queue', $this->queueExtender()
-            );
-        }
-    }
-
-    /**
-     * Get the queue extension callback.
-     *
-     * @return \Closure
-     */
-    protected function queueExtender()
-    {
-        return function () {
-            Queue::extend('sqs', function () {
-                return new VaporConnector;
-            });
-        };
     }
 
     /**


### PR DESCRIPTION
Things like `resolving()` and `extend()` should be safe to use in `register()` (as long as all other service providers "behave").

I did an entire talk about this pattern at last year's Laracon EU, so I was wondering what you think about this pattern. Or, if there was a specific reason for the comparatively complicated `resolved` / `afterResolving` trick.