### PR TITLE
Fix undefined method exception on non-Laravel responses

### DIFF
--- a/src/Runtime/Http/Middleware/EnsureVanityUrlIsNotIndexed.php
+++ b/src/Runtime/Http/Middleware/EnsureVanityUrlIsNotIndexed.php
@@ -15,8 +15,10 @@ class EnsureVanityUrlIsNotIndexed
     {
         $response = $next($request);
 
-        return 'https://'.$request->getHttpHost() === $_ENV['APP_VANITY_URL']
-                    ? $response->header('X-Robots-Tag', 'noindex, nofollow')
-                    : $response;
+        if ('https://'.$request->getHttpHost() === $_ENV['APP_VANITY_URL']) {
+            $response->headers->set('X-Robots-Tag', 'noindex, nofollow', true);
+        }
+
+        return $response;
     }
 }


### PR DESCRIPTION
I ran into an issue where my response was a `Symfony\Component\HttpFoundation\StreamedResponse` and it didn't have the `header()` method.

Wasn't sure where to post a bug report for Vapor, so I decided to submit an **un-tested** PR with a possible fix.

Use case is when providing a download via `Storage::download($file)`, where the disk used is S3.

PS. Would be very useful to have an issue board on this repo