### PR TITLE
Accept Auth Guard from Vapor JS

### DIFF
--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Vapor\Contracts\SignedStorageUrlController as SignedStorageUrlControllerContract;
 
@@ -21,6 +22,8 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
     public function store(Request $request)
     {
         $this->ensureEnvironmentVariablesAreAvailable($request);
+        
+        Auth::shouldUse($request->input('guard'));
 
         Gate::authorize('uploadFiles', [
             $request->user(),


### PR DESCRIPTION
Accept Auth Guard from Vapor JS applications having multiple guards. (E.g. Admin, Franchisee, Customer).
I have also created a pull request on the Vapor JS repo to allow for other Auth Guards.
Auth Guard would default to env's auth.defaults.guard, so we don't introduce breaking changes for existing users of Vapor.
https://github.com/laravel/vapor-js/pull/7