### PR TITLE
Handle Lambda Events from other AWS Services w/ CliHandler

### DIFF
--- a/stubs/cliRuntime.php
+++ b/stubs/cliRuntime.php
@@ -6,6 +6,7 @@ use Laravel\Vapor\Runtime\LambdaContainer;
 use Laravel\Vapor\Runtime\CliHandlerFactory;
 use Laravel\Vapor\Runtime\StorageDirectories;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
+use Laravel\Vapor\Runtime\Handlers\CliHandler;
 
 /*
 |--------------------------------------------------------------------------
@@ -62,6 +63,8 @@ $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
 
 while (true) {
     $lambdaRuntime->nextInvocation(function ($invocationId, $event) use ($invocations) {
+        $event = CliHandler::intercept($event);
+
         return CliHandlerFactory::make($event)
                         ->handle($event)
                         ->toApiGatewayFormat();

--- a/tests/CliHandlerFactoryTest.php
+++ b/tests/CliHandlerFactoryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Laravel\Vapor\Tests;
+
+use Illuminate\Support\Facades\Artisan;
+use Laravel\Vapor\Runtime\CliHandlerFactory;
+use Laravel\Vapor\Runtime\Handlers\CliHandler;
+use Laravel\Vapor\Runtime\Handlers\UnknownEventHandler;
+use Orchestra\Testbench\TestCase;
+
+class CliHandlerFactoryTest extends TestCase
+{
+    public function test_it_handles_lambda_events_listed_in_vapor_cli_file()
+    {
+        $_ENV['LAMBDA_TASK_ROOT'] = __DIR__ . '/Fixtures';
+
+        $event = [
+            'Records' => [
+                [
+                    'eventSource' => 'aws:s3',
+                ],
+            ],
+        ];
+
+        $event = CliHandler::intercept($event);
+        $handler = CliHandlerFactory::make($event);
+
+        $this->assertTrue(is_a($handler, CliHandler::class));
+    }
+
+    public function test_it_doesnt_handle_lambda_events_not_listed_in_vapor_cli_file()
+    {
+        $_ENV['LAMBDA_TASK_ROOT'] = __DIR__ . '/Fixtures';
+
+        $event = [
+            'Records' => [
+                [
+                    'eventSource' => 'aws:sns',
+                ],
+            ],
+        ];
+
+        $event = CliHandler::intercept($event);
+        $handler = CliHandlerFactory::make($event);
+
+        $this->assertTrue(is_a($handler, UnknownEventHandler::class));
+    }
+
+    public function test_it_handles_lambda_events_listed_in_vapor_cli_file_and_runs_the_associated_command()
+    {
+        $_ENV['LAMBDA_TASK_ROOT'] = __DIR__ . '/Fixtures';
+
+        $test = $this;
+
+        Artisan::command('s3:command {payload}', function () use ($test) {
+            $payload = json_decode(base64_decode($this->argument('payload')), true);
+
+            $test->assertTrue($payload['Records'][0]['s3']['bucket']['name'] === 'test-bucket');
+        });
+
+        $event = [
+            'Records' => [
+                [
+                    'eventSource' => 'aws:s3',
+                    's3' => [
+                        'bucket' => [
+                            'name' => 'test-bucket',
+                        ]
+                    ]
+                ],
+            ],
+        ];
+
+        $event = CliHandler::intercept($event);
+        
+        $this->artisan($event['cli'])->assertExitCode(0);
+    }
+}

--- a/tests/CliHandlerFactoryTest.php
+++ b/tests/CliHandlerFactoryTest.php
@@ -52,8 +52,8 @@ class CliHandlerFactoryTest extends TestCase
 
         $test = $this;
 
-        Artisan::command('s3:command {payload}', function () use ($test) {
-            $payload = json_decode(base64_decode($this->argument('payload')), true);
+        Artisan::command('s3:command {payload}', function ($payload) use ($test) {
+            $payload = json_decode(base64_decode($payload), true);
 
             $test->assertTrue($payload['Records'][0]['s3']['bucket']['name'] === 'test-bucket');
         });

--- a/tests/Fixtures/vapor/cli.php
+++ b/tests/Fixtures/vapor/cli.php
@@ -10,11 +10,11 @@
 | to handle ab event. Then add the command's signature in this file along with
 | a Closure that returns true if the event should be handled by your command.
 |
-| To utlilize the Lambda event's payload you must add a "--payload" option to
+| To utlilize the Lambda event's payload you must add a "{payload}" arguments to
 | both the command signature in this file and where you wrote the command.
 |
 |	return [
-|		'command:signature --payload' => function ($event) {
+|		'command:signature {payload}' => function ($event) {
 |			return $event['Records'][0]['eventSource'] === 'aws:s3';
 |		}
 |	];
@@ -24,7 +24,7 @@
 return [
     
     's3:command {payload}' => function ($event) {
-        return ($event['Records'][0]['eventSource'] ?? false) === 'aws:s3';
+        return ($event['Records'][0]['eventSource'] ?? '') === 'aws:s3';
     },
 
 ];

--- a/tests/Fixtures/vapor/cli.php
+++ b/tests/Fixtures/vapor/cli.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Lambda Event Console Commands
+|--------------------------------------------------------------------------
+|
+| Laravel console commands within your app can be executed by Vapor when events
+| events from AWS services reach the CLI Lambda. First create a console command
+| to handle ab event. Then add the command's signature in this file along with
+| a Closure that returns true if the event should be handled by your command.
+|
+| To utlilize the Lambda event's payload you must add a "--payload" option to
+| both the command signature in this file and where you wrote the command.
+|
+|	return [
+|		'command:signature --payload' => function ($event) {
+|			return $event['Records'][0]['eventSource'] === 'aws:s3';
+|		}
+|	];
+|
+*/
+
+return [
+    
+    's3:command {payload}' => function ($event) {
+        return ($event['Records'][0]['eventSource'] ?? false) === 'aws:s3';
+    },
+
+];


### PR DESCRIPTION
_Already emailed @themsaid about this but also wanted to share my thoughts in a PR as my use cases for this are starting to stack up :)_

----

I would like to use Laravel Vapor's cli Lambda to handle other services in the AWS ecosystem. Many services like S3, SES, SNS, and API Gateway have the ability to invoke Lambdas:

https://docs.aws.amazon.com/lambda/latest/dg/lambda-services.html

This PR allows developers to provide callbacks that map their Console Commands to handle Lambda events by evaluating the the event payload and determining if a command should intercept it. Currently any events that are sent to the Lambda that are not recognized by `CliHandlerFactory` are just handled by `UnknownEventHandler`.

## How it works
This setup requires a file to be added to the application root named `/vapor/cli.php`. Within this file the developer can define a list of command signatures and closures that determine if the command should be used to handle an event.

### Create a Console Commmand

```php
// Handles a Lambda event that is triggered when a new object is added to a bucket.

Artisan::command('image:resize {payload}', function ($payload) {
    $payload = json_decode(base64_decode($payload), true);

    $file = Storage::get($payload['Records'][0]['s3']['object']['key']);

    ...
});
```

### Add the command signature to the Vapor Cli file

```php
return [

    ‘image:resize’ => function ($event) {
        return ($event['Records'][0]['eventSource'] ?? '') === 'aws:s3' &&
           ($event['Records'][0]['s3']['bucket']['name'] ?? '') === 'image-bucket';
    },

];
```

If accepted we would need an easy way to add the `/vapor/cli.php` file within the application directory. Probably could be a command added to `vapor-cli` to create this file from a stub.


