### PR TITLE
Use the last value of each multi value header array.

### DIFF
--- a/src/Runtime/Fpm/FpmRequest.php
+++ b/src/Runtime/Fpm/FpmRequest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Vapor\Runtime\Fpm;
 
+use Illuminate\Support\Arr;
 use hollodotme\FastCGI\Interfaces\ProvidesRequestData;
 
 class FpmRequest implements ProvidesRequestData
@@ -157,7 +158,7 @@ class FpmRequest implements ProvidesRequestData
         return array_change_key_case(
             collect($event['multiValueHeaders'] ?? [])
                 ->mapWithKeys(function ($headers, $name) {
-                    return [$name => $headers[0]];
+                    return [$name => Arr::last($headers)];
                 })->all(), CASE_LOWER
         );
     }

--- a/tests/FpmRequestTest.php
+++ b/tests/FpmRequestTest.php
@@ -28,4 +28,79 @@ class FpmRequestTest extends TestCase
 
         $this->assertEquals(http_build_query(['Host' => urldecode($host)]), $request->serverVariables['QUERY_STRING']);
     }
+
+    public function test_api_gateway_headers_are_handled()
+    {
+        $trace = 'Root=1-7696740c-c075312a25f21abe1ca19805;foobar';
+        $for = '172.105.167.153, 70.132.20.166';
+        $port = '443';
+        $proto = 'https';
+
+        $request = FpmRequest::fromLambdaEvent([
+            'httpMethod' => 'GET',
+            'headers' => [
+                'X-Amzn-Trace-Id' => $trace,
+                'X-Forwarded-For' => $for,
+                'X-Forwarded-Port' => $port,
+                'X-Forwarded-Proto' => $port
+            ],
+            'multiValueHeaders' => [
+                'X-Amzn-Trace-Id' => [
+                    $trace,
+                ],
+                'X-Forwarded-For' => [
+                    $for,
+                ],
+                'X-Forwarded-Port' => [
+                    $port,
+                ],
+                'X-Forwarded-Proto' => [
+                    $proto,
+                ],
+            ],
+            'queryStringParameters' => null,
+            'multiValueQueryStringParameters' => null,
+        ], 'index.php');
+
+        $this->assertEquals($trace, $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
+        $this->assertEquals($for, $request->serverVariables['HTTP_X_FORWARDED_FOR']);
+        $this->assertEquals($port, $request->serverVariables['HTTP_X_FORWARDED_PORT']);
+        $this->assertEquals($proto, $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
+    }
+
+    public function test_load_balancer_headers_are_over_spoofed_headers()
+    {
+        $request = FpmRequest::fromLambdaEvent([
+            'requestContext' => [
+                'elb' => [
+                    'targetGroupArn' => 'arn:aws:elasticloadbalancing:us-west-2:308264878215:targetgroup/vapor-staging/2aa8690968087e6e',
+                ],
+            ],
+            'httpMethod' => 'GET',
+            'multiValueQueryStringParameters' => [],
+            'multiValueHeaders' => [
+                'x-amzn-trace-id' => [
+                    'foobar',
+                    $trace = 'Root=1-7696740c-c075312a25f21abe1ca19805;foobar',
+                ],
+                'x-forwarded-for' => [
+                    '8.8.8.8',
+                    $for = '8.8.8.8, 172.105.167.153',
+                ],
+                'x-forwarded-port' => [
+                    '69',
+                    $port = '443',
+                ],
+                'x-forwarded-proto' => [
+                    'http',
+                    $proto = 'https',
+                ],
+            ],
+        ], 'index.php');
+
+        $this->assertEquals($trace, $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
+        $this->assertEquals($for, $request->serverVariables['HTTP_X_FORWARDED_FOR']);
+        $this->assertEquals($port, $request->serverVariables['HTTP_X_FORWARDED_PORT']);
+        $this->assertEquals($proto, $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
+    }
 }


### PR DESCRIPTION
While attempting to get the user's IP I have come across an issue where the user can spoof the IP in the `x-forwarded-for` header  when using the Load Balancer(as well as other ELB headers).

For example if the request is something like (giving it my own `x-forwarded-for` header):
```
curl 'https://vapor.app' -H 'x-forwarded-for: 8.8.8.8' 
```
and my IP is something like `1.1.1.1`

The expected value for `x-forwarded-for` should be `8.8.8.8, 1.1.1.1` . Instead, the value that appears in the Laravel request is `8.8.8.8`. This means I can effectively spoof the IP of my request or at least as far as the Laravel app is concerned.

It looks like when `Mutli value headers` is enabled on the AWS Target Group rather than overriding the header the Load Balancer appears to append it's own one.

So the Lambda event `multiValueHeaders` looks like this:

```php
[
    // ...
    'multiValueHeaders' => [
        // ...
        'x-forwarded-for' => [
            '8.8.8.8',
            '8.8.8.8, 1.1.1.1',
        ],
        // ...
    ],
    // ...
];
```

So to fix this issue we should use the last item in each header array. This is a simple PR that does just that. I have also included tests to make sure this is indeed fixed and is still backwards compatible with API Gateway and single value Load Balancer requests.

I hope this is enough, I can provide more information and dumps of required.
