### PR TITLE
Allow handling custom events via the api lambda

### DIFF
--- a/src/Runtime/CliHandlerFactory.php
+++ b/src/Runtime/CliHandlerFactory.php
@@ -16,12 +16,8 @@ class CliHandlerFactory
      */
     public static function make(array $event)
     {
-        if (isset($event['cli'])) {
-            return new CliHandler;
-        } elseif (isset($event['Records'][0]['messageId'])) {
-            return new QueueHandler;
-        } else {
-            return new UnknownEventHandler;
-        }
+        return isset($event['Records'][0]['messageId'])
+                    ? new QueueHandler
+                    : new CliHandler;
     }
 }

--- a/src/Runtime/Handlers/CliHandler.php
+++ b/src/Runtime/Handlers/CliHandler.php
@@ -24,7 +24,8 @@ class CliHandler implements LambdaEventHandler
 
         $process = Process::fromShellCommandline(
             sprintf("/opt/bin/php %s/artisan %s --no-interaction 2>&1",
-                $_ENV['LAMBDA_TASK_ROOT'], trim($event['cli'])
+                $_ENV['LAMBDA_TASK_ROOT'],
+                trim($event['cli'] ?? 'vapor:handle '.base64_encode(json_encode($event)))
             )
         )->setTimeout(null);
 

--- a/src/VaporServiceProvider.php
+++ b/src/VaporServiceProvider.php
@@ -2,12 +2,14 @@
 
 namespace Laravel\Vapor;
 
+use InvalidArgumentException;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Vapor\Queue\VaporConnector;
 use Laravel\Vapor\Console\Commands\VaporWorkCommand;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Laravel\Vapor\Http\Controllers\SignedStorageUrlController;
 
 class VaporServiceProvider extends ServiceProvider
@@ -94,6 +96,12 @@ class VaporServiceProvider extends ServiceProvider
         if (! $this->app->runningInConsole()) {
             return;
         }
+
+        $this->app[ConsoleKernel::class]->command('vapor:handle {payload}',function (){
+            throw new InvalidArgumentException(
+                'Unknown event type. Please fine a vapor:handle command to handle custom events.'
+            );
+        });
 
         $this->app->singleton('command.vapor.work', function ($app) {
             return new VaporWorkCommand($app['queue.vaporWorker']);

--- a/src/VaporServiceProvider.php
+++ b/src/VaporServiceProvider.php
@@ -97,7 +97,7 @@ class VaporServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->app[ConsoleKernel::class]->command('vapor:handle {payload}',function (){
+        $this->app[ConsoleKernel::class]->command('vapor:handle {payload}',function () {
             throw new InvalidArgumentException(
                 'Unknown event type. Please fine a vapor:handle command to handle custom events.'
             );


### PR DESCRIPTION
This is a different approach to https://github.com/laravel/vapor-core/pull/24

If the CLI lambda receives an event that's not a CLI command or from SQS. It'll attempt to run a `vapor:handle {payload}` command where the payload is base64 encoded version of the event payload.

People can define this command in their applications and handle custom lambda events.