### PR TITLE
Use "api" guard on signed storage route.

### DIFF
--- a/src/DefinesRoutes.php
+++ b/src/DefinesRoutes.php
@@ -20,6 +20,6 @@ trait DefinesRoutes
         Route::post(
             '/vapor/signed-storage-url',
             Contracts\SignedStorageUrlController::class.'@store'
-        )->middleware('web');
+        )->middleware(request()->expectsJson() ? 'auth:api' : 'web');
     }
 }


### PR DESCRIPTION
If I'm not missing something, the route `/vapor/signed-storage-url` doesn't work for requests sent from an SPA or mobile app.
I believe the guard can be switched from `web` to `auth:api` for requests that expect a JSON response.