### PR TITLE
Use new queue suffix option

### DIFF
--- a/src/Queue/VaporConnector.php
+++ b/src/Queue/VaporConnector.php
@@ -25,7 +25,8 @@ class VaporConnector implements ConnectorInterface
         return new VaporQueue(
             new SqsClient($config),
             $config['queue'],
-            $config['prefix'] ?? ''
+            $config['prefix'] ?? '',
+            $config['suffix'] ?? ''
         );
     }
 


### PR DESCRIPTION
This ensures that the vapor connector receives the new suffix option that was added in https://github.com/laravel/framework/pull/31784