### PR TITLE
Allow symfony/psr-http-message-bridge 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "monolog/monolog": "^1.12|^2.0",
         "riverline/multipart-parser": "^2.0",
         "symfony/process": "^4.3|^5.0",
-        "symfony/psr-http-message-bridge": "^1.2",
+        "symfony/psr-http-message-bridge": "^1.2|^2.0",
         "zendframework/zend-diactoros": "^2.1"
     },
     "require-dev": {


### PR DESCRIPTION
Issue with laravel 7 

As noted by the docs:
The Zend Diactoros library for generating PSR-7 responses has been deprecated. If you are using this package for PSR-7 compatibility, please install the nyholm/psr7 Composer package instead. In addition, **please install the ^2.0 release of the symfony/psr-http-message-bridge** Composer package.