### PR TITLE
[2.0] Allow any S3 service signed Uri response

### DIFF
--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -42,7 +42,7 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
             'uuid' => $uuid,
             'bucket' => $bucket,
             'key' => $key,
-            'url' => 'https://'.$uri->getHost().$uri->getPath().'?'.$uri->getQuery(),
+            'url' => (string) $uri,
             'headers' => $this->headers($request, $signedRequest),
         ], 201);
     }

--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -128,6 +128,8 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
                 'secret' => $_ENV['AWS_SECRET_ACCESS_KEY'] ?? null,
                 'token' => $_ENV['AWS_SESSION_TOKEN'] ?? null,
             ]);
+
+            $config['endpoint'] = $_ENV['AWS_ENDPOINT'] ?? null;
         }
 
         return S3Client::factory($config);

--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -120,7 +120,7 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
             'region' => $_ENV['AWS_DEFAULT_REGION'],
             'version' => 'latest',
             'signature_version' => 'v4',
-            'endpoint' => $_ENV['AWS_ENDPOINT'] ?? null;
+            'endpoint' => $_ENV['AWS_ENDPOINT'] ?? null,
         ];
 
         if (! isset($_ENV['AWS_LAMBDA_FUNCTION_VERSION'])) {

--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -120,6 +120,7 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
             'region' => $_ENV['AWS_DEFAULT_REGION'],
             'version' => 'latest',
             'signature_version' => 'v4',
+            'endpoint' => $_ENV['AWS_ENDPOINT'] ?? null;
         ];
 
         if (! isset($_ENV['AWS_LAMBDA_FUNCTION_VERSION'])) {
@@ -128,8 +129,6 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
                 'secret' => $_ENV['AWS_SECRET_ACCESS_KEY'] ?? null,
                 'token' => $_ENV['AWS_SESSION_TOKEN'] ?? null,
             ]);
-
-            $config['endpoint'] = $_ENV['AWS_ENDPOINT'] ?? null;
         }
 
         return S3Client::factory($config);


### PR DESCRIPTION
When developing locally I use Minio as my s3 service. I have this running on port 9000.

With the current setup I'd have to override the whole `store` method just to change the url in the response.

To get the URL from the signed request you can cast the Uri to a string to get what you need instead of building the URL manually.

Also discussed here: https://github.com/laravel/vapor-core/pull/20