### PR TITLE
Allow for authorization override in the signed storage url controller

### DIFF
--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -22,10 +22,7 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
     {
         $this->ensureEnvironmentVariablesAreAvailable($request);
 
-        Gate::authorize('uploadFiles', [
-            $request->user(),
-            $bucket = $request->input('bucket') ?: $_ENV['AWS_BUCKET']
-        ]);
+        $this->authorize($request, $bucket = $request->input('bucket') ?: $_ENV['AWS_BUCKET']);
 
         $client = $this->storageClient();
 
@@ -107,6 +104,21 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
         throw new InvalidArgumentException(
             "Unable to issue signed URL. Missing environment variables: ".implode(', ', array_keys($missing))
         );
+    }
+
+    /**
+     * Authorize the request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  string                   $bucket
+     * @return void
+     */
+    protected function authorize(Request $request, $bucket)
+    {
+        Gate::authorize('uploadFiles', [
+            $request->user(),
+            $bucket
+        ]);
     }
 
     /**


### PR DESCRIPTION
I'd like a little more control over the authorization in the SignedStorageUrlController.php as when the `$request->user()` returns `null` there is no way to use the controller without rewriting large portions of it.

In this MR I have taken the autorization logic into a seperate method so that the controller can be extended to just override the authorization aspect of this controller.