### PR TITLE
Make redirects optional

### DIFF
--- a/config/vapor.php
+++ b/config/vapor.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Str;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Redirect robots.txt
+    |--------------------------------------------------------------------------
+    |
+    | When this option is enabled, Vapor will redirect requests to the
+    | robots.txt file to the location in your assets S# bucket or
+    | Cloudfront distribution.
+    |
+    */
+
+    'redirect_robots_txt' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Redirect www to the root domain
+    |--------------------------------------------------------------------------
+    |
+    | When this option is enabled, Vapor will redirect requests to the
+    | www subdomain to the root domain. If the option is disabled,
+    | vapor will redirect the root domain to the www subdomain.
+    |
+    */
+
+    'redirect_www' => true,
+];

--- a/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
+++ b/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
@@ -16,10 +16,19 @@ class EnsureOnNakedDomain
      */
     public function handle($request, $next)
     {
-        if (strpos($request->getHost(), 'www.') === 0) {
+        if (config('vapor.redirect_www') &&
+            strpos($request->getHost(), 'www.') === 0) {
             return new RedirectResponse(Str::replaceFirst(
                 'www.', '', $request->fullUrl()
             ), 301);
+        }
+
+        if (! config('vapor.redirect_www') &&
+            strpos($request->getHost(), 'www.') === false) {
+            return new RedirectResponse(
+                'www.'.$request->fullUrl(),
+                301
+            );
         }
 
         return $next($request);

--- a/src/Runtime/Http/Middleware/RedirectStaticAssets.php
+++ b/src/Runtime/Http/Middleware/RedirectStaticAssets.php
@@ -21,7 +21,7 @@ class RedirectStaticAssets
             ]);
         }
 
-        if ($request->path() === 'robots.txt') {
+        if (config('vapor.redirect_robots_txt') && $request->path() === 'robots.txt') {
             return new RedirectResponse($_ENV['ASSET_URL'].'/robots.txt', 302, [
                 'Cache-Control' => 'public, max-age=3600',
             ]);

--- a/src/VaporServiceProvider.php
+++ b/src/VaporServiceProvider.php
@@ -64,6 +64,8 @@ class VaporServiceProvider extends ServiceProvider
             SignedStorageUrlController::class
         );
 
+        $this->configure();
+        $this->offerPublishing();
         $this->ensureAssetPathsAreConfigured();
         $this->ensureRedisIsConfigured();
         $this->ensureDynamoDbIsConfigured();
@@ -72,6 +74,32 @@ class VaporServiceProvider extends ServiceProvider
         $this->ensureMixIsConfigured();
 
         $this->registerCommands();
+    }
+
+    /**
+     * Setup the configuration for Horizon.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/vapor.php', 'vapor'
+        );
+    }
+
+    /**
+     * Setup the resource publishing groups for Horizon.
+     *
+     * @return void
+     */
+    protected function offerPublishing()
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/vapor.php' => config_path('vapor.php'),
+            ], 'vapor-config');
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds a vapor.php configuration file with 2 attributes. One to enable/disable robots.txt redirect. And the other is to make redirecting www to root domain optional.