### PR TITLE
Remove Diactoros

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "monolog/monolog": "^1.12|^2.0",
         "riverline/multipart-parser": "^2.0",
         "symfony/process": "^4.3|^5.0",
-        "laminas/laminas-diactoros": "^2.2",
         "nyholm/psr7": "^1.0",
         "symfony/psr-http-message-bridge": "^1.0|^2.0"
     },

--- a/src/Runtime/Handlers/AppHandler.php
+++ b/src/Runtime/Handlers/AppHandler.php
@@ -7,14 +7,11 @@ use Illuminate\Container\Container;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Facade;
-use Laminas\Diactoros\ResponseFactory;
-use Laminas\Diactoros\ServerRequestFactory;
-use Laminas\Diactoros\StreamFactory;
-use Laminas\Diactoros\UploadedFileFactory;
 use Laravel\Vapor\Contracts\LambdaEventHandler;
 use Laravel\Vapor\Runtime\Http\PsrRequestFactory;
 use Laravel\Vapor\Runtime\HttpKernel;
 use Laravel\Vapor\Runtime\PsrLambdaResponseFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
@@ -36,12 +33,13 @@ class AppHandler implements LambdaEventHandler
                 (new HttpFoundationFactory)->createRequest($this->marshalRequest($event))
             ));
 
+            $psr17Factory = new Psr17Factory();
             return $this->marshalResponse(
                 (new PsrHttpFactory(
-                    new ServerRequestFactory,
-                    new StreamFactory,
-                    new UploadedFileFactory,
-                    new ResponseFactory
+                    $psr17Factory,
+                    $psr17Factory,
+                    $psr17Factory,
+                    $psr17Factory
                 ))->createResponse($response)
             );
         } finally {

--- a/src/Runtime/Http/PsrRequestFactory.php
+++ b/src/Runtime/Http/PsrRequestFactory.php
@@ -5,10 +5,10 @@ namespace Laravel\Vapor\Runtime\Http;
 use Illuminate\Support\Arr as SupportArr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Nyholm\Psr7\ServerRequest;
+use Nyholm\Psr7\Stream;
+use Nyholm\Psr7\UploadedFile;
 use Riverline\MultiPartParser\Part;
-use Zend\Diactoros\ServerRequest;
-use Zend\Diactoros\Stream;
-use Zend\Diactoros\UploadedFile;
 
 class PsrRequestFactory
 {
@@ -42,18 +42,21 @@ class PsrRequestFactory
 
         parse_str($queryString, $query);
 
-        return new ServerRequest(
-            $this->serverVariables($headers, $queryString),
-            $this->uploadedFiles($headers),
-            $this->uri(),
+        $serverRequest = new ServerRequest(
             $this->method(),
-            $this->bodyStream(),
+            $this->uri(),
             $headers,
-            $this->cookies($headers),
-            $query,
-            $this->parsedBody($headers),
-            $this->protocolVersion()
+            $this->bodyStream(),
+            $this->protocolVersion(),
+            $this->serverVariables($headers, $queryString)
         );
+
+        $serverRequest = $serverRequest->withParsedBody($this->parsedBody($headers));
+        $serverRequest = $serverRequest->withUploadedFiles($this->uploadedFiles($headers));
+        $serverRequest = $serverRequest->withCookieParams($this->cookies($headers));
+        $serverRequest = $serverRequest->withQueryParams($query);
+
+        return $serverRequest;
     }
 
     /**
@@ -167,17 +170,11 @@ class PsrRequestFactory
     /**
      * Get the HTTP request body stream.
      *
-     * @return \Zend\Diactoros\Stream
+     * @return \Psr\Http\Message\StreamInterface
      */
     protected function bodyStream()
     {
-        $stream = fopen('php://memory', 'r+');
-
-        fwrite($stream, $this->bodyString());
-
-        rewind($stream);
-
-        return new Stream($stream);
+        return Stream::create($this->bodyString());
     }
 
     /**
@@ -274,7 +271,7 @@ class PsrRequestFactory
      * Create a new file instance from the given HTTP request document part.
      *
      * @param  \Riverline\MultipartParser\Part  $part
-     * @return \Zend\Diactoros\UploadedFile
+     * @return \Psr\Http\Message\UploadedFileInterface
      */
     protected function createFile($part)
     {
@@ -284,8 +281,11 @@ class PsrRequestFactory
         );
 
         return new UploadedFile(
-            $path, filesize($path), UPLOAD_ERR_OK,
-            $part->getFileName(), $part->getMimeType()
+            $path,
+            filesize($path),
+            UPLOAD_ERR_OK,
+            $part->getFileName(),
+            $part->getMimeType()
         );
     }
 


### PR DESCRIPTION
We currently have 3 PSR7 implementations installed. Diactoros, Guzzle/psr7 and Nyholm/psr7. As #44 removes Guzzle, I thought it would be a good idea to remove Diactoros. 

Why Nyholm/psr7 over Diactoros? They are pretty much the same. Diactoros v2 is 100% compatible with the PSR7 specification after I shared the test suite from Nyholm/psr7. Symfony has chosen to use Nyholm/psr7 over others which makes it a little smoother integration with their HTTP Client and some other components.

But again, they are pretty much the same and I think one of them should be removed. 
