### PR TITLE
Detect binary encoding and add X-Vapor-Base64-Encode

### DIFF
--- a/src/Runtime/Http/Middleware/EnsureBinaryEncoding.php
+++ b/src/Runtime/Http/Middleware/EnsureBinaryEncoding.php
@@ -30,9 +30,7 @@ class EnsureBinaryEncoding
     {
         $contentType = strtolower($response->headers->get('Content-Type', 'text/html'));
 
-        $textTypes = ['application/json', 'application/xml', 'application/xhtml+xml'];
-
-        if (!$contentType || in_array($contentType, $textTypes, true) || Str::startsWith($contentType, 'text/')) {
+        if (Str::startsWith($contentType, 'text/') || Str::contains($contentType, ['xml', 'json'])) {
             return false;
         }
 

--- a/src/Runtime/Http/Middleware/EnsureBinaryEncoding.php
+++ b/src/Runtime/Http/Middleware/EnsureBinaryEncoding.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Laravel\Vapor\Runtime\Http\Middleware;
+
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureBinaryEncoding
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  callable  $next
+     * @return mixed
+     */
+    public function handle($request, $next)
+    {
+        /** @var \Illuminate\Http\Response $response */
+        $response = $next($request);
+
+        if (static::isBase64EncodingRequired($response)) {
+            $response->headers->set('X-Vapor-Base64-Encode', 'True');
+        }
+
+        return $response;
+    }
+
+    public static function isBase64EncodingRequired(Response $response) : bool
+    {
+        $contentType = strtolower($response->headers->get('Content-Type', 'text/html'));
+
+        $textTypes = ['application/json', 'application/xml', 'application/xhtml+xml'];
+
+        if (!$contentType || in_array($contentType, $textTypes, true) || Str::startsWith($contentType, 'text/')) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/HttpKernelTest.php
+++ b/tests/HttpKernelTest.php
@@ -58,6 +58,16 @@ class HttpKernelTest extends TestCase
         ]);
         $this->assertFalse(EnsureBinaryEncoding::isBase64EncodingRequired($response));
 
+        $response = new Response("{}", 200, [
+            'Content-Type' => 'application/vnd.api+json; charset=UTF-8',
+        ]);
+        $this->assertFalse(EnsureBinaryEncoding::isBase64EncodingRequired($response));
+
+        $response = new Response("*", 200, [
+            'Content-Type' => 'application/octet-stream',
+        ]);
+        $this->assertTrue(EnsureBinaryEncoding::isBase64EncodingRequired($response));
+
         $response = new Response('*', 200, [
             'Content-Type' => 'image/png',
         ]);

--- a/tests/HttpKernelTest.php
+++ b/tests/HttpKernelTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Vapor\Tests;
 
+use Laravel\Vapor\Runtime\Http\Middleware\EnsureBinaryEncoding;
 use Mockery;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -45,5 +46,21 @@ class HttpKernelTest extends TestCase
 
         $this->assertFalse(HttpKernel::shouldSendMaintenanceModeResponse(Request::create('/', 'GET')));
         $this->assertFalse(HttpKernel::shouldSendMaintenanceModeResponse(Request::create('http://something.com', 'GET')));
+    }
+
+    public function test_should_send_isbase64encode_on_binary_response()
+    {
+        $response = new Response('ok', 200);
+        $this->assertFalse(EnsureBinaryEncoding::isBase64EncodingRequired($response));
+
+        $response = new Response("{}", 200, [
+            'Content-Type' => 'application/json',
+        ]);
+        $this->assertFalse(EnsureBinaryEncoding::isBase64EncodingRequired($response));
+
+        $response = new Response('*', 200, [
+            'Content-Type' => 'image/png',
+        ]);
+        $this->assertTrue(EnsureBinaryEncoding::isBase64EncodingRequired($response));
     }
 }


### PR DESCRIPTION
Not sure if there is a reason why we cannot just detect the encoding of the responses? I think that would make it easier to integrate third party libraries for images/libraries etc.

Haven't tested this in Vapor yet and not sure how to best handle the unit tests, because there doesn't seem to be a test for the Responses yet?

Edit: I chose a safe-list for text instead of the other way around, because the rest on this list is binary: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
You could argue that application/json also might be binary? Not sure