### PR TITLE
Set TrustedProxies to allow all

### DIFF
--- a/src/VaporServiceProvider.php
+++ b/src/VaporServiceProvider.php
@@ -122,7 +122,7 @@ class VaporServiceProvider extends ServiceProvider
      */
     private function configureTrustedProxy()
     {
-        Config::set('trustedproxy.proxies', '*');
+        Config::set('trustedproxy.proxies', ['0.0.0.0/0', '2000:0:0:0:0:0:0:0/3']);
     }
 
     /**


### PR DESCRIPTION
The requestIp() is currently not the expected IP. Steps to reproduce:

 - Create new Laravel project (`laravel new ...`)
 - Init Vapor, default settings (`vapor init`)
 - Add route that outputs `request()->getClientIp()` 
 - Deploy with Vapor
 - Expected: My IP (eg https://www.whatismyip.com/)
 - Result: Wrong IP
 
Based on https://github.com/fideloper/TrustedProxy/issues/115#issuecomment-469459016

If you dump `request()->getClientIps()` you see your own IP as the 2nd one, but `request()->getClientIp()` always returns the first.
