### PR TITLE
url and endpoint config location

### DIFF
--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -127,9 +127,11 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
                 'key' => $_ENV['AWS_ACCESS_KEY_ID'] ?? null,
                 'secret' => $_ENV['AWS_SECRET_ACCESS_KEY'] ?? null,
                 'token' => $_ENV['AWS_SESSION_TOKEN'] ?? null,
-                'url' => $_ENV['AWS_URL'] ?? null,
-                'endpoint' => $_ENV['AWS_URL'] ?? null,
             ]);
+            if(array_key_exists('AWS_URL', $_ENV)) {
+                $config['url'] = $_ENV['AWS_URL'];
+                $config['endpoint'] = $_ENV['AWS_URL'];
+            }
         }
 
         return S3Client::factory($config);

--- a/tests/SignedStorageUrlControllerTest.php
+++ b/tests/SignedStorageUrlControllerTest.php
@@ -41,6 +41,18 @@ class SignedStorageUrlControllerTest extends TestCase
         // ]));
     }
 
+    public function test_aws_url_environmental_variable_is_used()
+    {
+        $_ENV['AWS_URL'] = 'http://custom-url';
+        Gate::define('uploadFiles', function ($user = null, $bucket) {
+            return true;
+        });
+
+        $response = $this->withoutExceptionHandling()->json('POST', '/vapor/signed-storage-url?content_type=text/plain');
+        $response->assertStatus(201);
+        $this->assertStringContainsString('laravel-s3-test-1.custom-url', $response->original['url']);
+    }
+
 
     public function test_cant_retrieve_signed_urls_without_proper_environment_variables()
     {


### PR DESCRIPTION
URL and endpoint do not belong in the credentials subarray.

https://github.com/aws/aws-sdk-php/blob/3c5a921f0de917f9fc3d51b2970106d3abfc6b8f/src/S3/S3Client.php#L363-L365
https://github.com/aws/aws-sdk-php/blob/3c5a921f0de917f9fc3d51b2970106d3abfc6b8f/src/AwsClient.php#L198

If AWS_URL is set in the .env file it is currently ignored when using the '/vapor/signed-storage-url' endpoint and the default 's3.amazonaws.com' endpoint is used.

(I have a strong feeling there is a better way to handle this and would have instead created an issue but was unable)