### PR TITLE
Ensure http handler terminates application after response is sent

### DIFF
--- a/src/Runtime/Handlers/AppHandler.php
+++ b/src/Runtime/Handlers/AppHandler.php
@@ -29,7 +29,7 @@ class AppHandler implements LambdaEventHandler
         try {
             $app = require $_ENV['LAMBDA_TASK_ROOT'].'/bootstrap/app.php';
 
-            $response = (new HttpKernel($app))->handle(Request::createFromBase(
+            [$response] = (new HttpKernel($app))->handle(Request::createFromBase(
                 (new HttpFoundationFactory)->createRequest($this->marshalRequest($event))
             ));
 

--- a/src/Runtime/HttpKernel.php
+++ b/src/Runtime/HttpKernel.php
@@ -50,8 +50,6 @@ class HttpKernel
                 file_get_contents($_ENV['LAMBDA_TASK_ROOT'].'/503.html'),
                 503
             );
-
-            $this->app->instance('middleware.disable', true);
         } else {
             $response = (new Pipeline)->send($request)
                 ->through([

--- a/stubs/httpHandler.php
+++ b/stubs/httpHandler.php
@@ -55,7 +55,7 @@ $app = require_once __DIR__.'/bootstrap/app.php';
 
 $handler = new HttpKernel($app);
 
-[$response, $kernel] = $handler->handle(Request::capture());
+[$response, $kernel] = $handler->handle($request = Request::capture());
 
 $response->send();
 

--- a/stubs/httpHandler.php
+++ b/stubs/httpHandler.php
@@ -55,6 +55,8 @@ $app = require_once __DIR__.'/bootstrap/app.php';
 
 $handler = new HttpKernel($app);
 
-$response = $handler->handle(Request::capture());
+[$response, $kernel] = $handler->handle(Request::capture());
 
 $response->send();
+
+$kernel->terminate($request, $response);


### PR DESCRIPTION
The `httpHandler` is currently terminating the app before the response is sent. I've made some changes to terminate after the response but not entirely sure how to test locally. Let me know if any changes are needed. Thanks!