### PR TITLE
Only force redirect APP_URL host to www

### DIFF
--- a/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
+++ b/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
@@ -29,7 +29,7 @@ class EnsureOnNakedDomain
 
         if (! config('vapor.redirect_to_root') &&
             strpos($request->getHost(), 'www.') === false &&
-            $request->getHost() === parse_url($_ENV['APP_URL'], PHP_URL_HOST)) {
+            in_array(parse_url($_ENV['APP_URL'], PHP_URL_HOST), [$request->getHost(), 'www.'. $request->getHost()])) {
             return new RedirectResponse(str_replace(
                 $request->getScheme().'://',
                 $request->getScheme().'://www.',

--- a/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
+++ b/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
@@ -29,7 +29,7 @@ class EnsureOnNakedDomain
 
         if (! config('vapor.redirect_to_root') &&
             strpos($request->getHost(), 'www.') === false &&
-            in_array(parse_url($_ENV['APP_URL'], PHP_URL_HOST), [$request->getHost(), 'www.'. $request->getHost()])) {
+            in_array(parse_url($_ENV['APP_URL'], PHP_URL_HOST), [$request->getHost(), 'www.'. $request->getHost()], true)) {
             return new RedirectResponse(str_replace(
                 $request->getScheme().'://',
                 $request->getScheme().'://www.',

--- a/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
+++ b/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
@@ -28,7 +28,8 @@ class EnsureOnNakedDomain
         }
 
         if (! config('vapor.redirect_to_root') &&
-            strpos($request->getHost(), 'www.') === false) {
+            strpos($request->getHost(), 'www.') === false &&
+            $request->getHost() === parse_url($_ENV['APP_URL'], PHP_URL_HOST)) {
             return new RedirectResponse(str_replace(
                 $request->getScheme().'://',
                 $request->getScheme().'://www.',

--- a/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
+++ b/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
@@ -29,7 +29,7 @@ class EnsureOnNakedDomain
 
         if (! config('vapor.redirect_to_root') &&
             strpos($request->getHost(), 'www.') === false &&
-            in_array(parse_url($_ENV['APP_URL'], PHP_URL_HOST), [$request->getHost(), 'www.'. $request->getHost()], true)) {
+            in_array(parse_url($_ENV['APP_URL'], PHP_URL_HOST), [$request->getHost(), 'www.' . $request->getHost()], true)) {
             return new RedirectResponse(str_replace(
                 $request->getScheme().'://',
                 $request->getScheme().'://www.',

--- a/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
+++ b/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
@@ -29,7 +29,7 @@ class EnsureOnNakedDomain
 
         if (! config('vapor.redirect_to_root') &&
             strpos($request->getHost(), 'www.') === false &&
-            in_array(parse_url($_ENV['APP_URL'], PHP_URL_HOST), [$request->getHost(), 'www.' . $request->getHost()], true)) {
+            in_array(parse_url($_ENV['APP_URL'], PHP_URL_HOST), [$request->getHost(), 'www.'.$request->getHost()], true)) {
             return new RedirectResponse(str_replace(
                 $request->getScheme().'://',
                 $request->getScheme().'://www.',


### PR DESCRIPTION
When using the config `'redirect_to_root' => false` Vapor was assuming any non-www host was the root domain, which isn't true for applications that route different subdomains in their `RouteServiceProvider` (e.g. `api.domain.com => routes/api.php`).

With the current logic `https://api.domain.com` always redirects to `https://www.api.domain.com`.

This PR fixes the issue by adding an additional check to ensure the request host matches the `APP_URL` host before forcing a redirect to `www`.