### PR TITLE
set aws session token

### DIFF
--- a/src/ConfiguresDynamoDb.php
+++ b/src/ConfiguresDynamoDb.php
@@ -26,5 +26,10 @@ trait ConfiguresDynamoDb
             'table' => $_ENV['DYNAMODB_CACHE_TABLE'] ?? 'cache',
             'endpoint' => $_ENV['DYNAMODB_ENDPOINT'] ?? null,
         ], Config::get('cache.stores.dynamodb') ?? []));
+
+        // if the key are the same as $_ENV after merged, set session_token
+        if (Config::get('cache.stores.dynamodb.key') === ($_ENV['AWS_ACCESS_KEY_ID'] ?? null)) {
+            Config::set('cache.stores.dynamodb.token', $_ENV['AWS_SESSION_TOKEN'] ?? null);
+        }
     }
 }

--- a/src/ConfiguresSqs.php
+++ b/src/ConfiguresSqs.php
@@ -26,5 +26,10 @@ trait ConfiguresSqs
             'queue' => $_ENV['SQS_QUEUE'] ?? 'default',
             'region' => $_ENV['AWS_DEFAULT_REGION'] ?? 'us-east-1',
         ], Config::get('queue.connections.sqs') ?? []));
+
+        // if the key are the same as $_ENV after merged, set session_token
+        if (Config::get('queue.connections.sqs.key') === ($_ENV['AWS_ACCESS_KEY_ID'] ?? null)) {
+            Config::set('queue.connections.sqs.token', $_ENV['AWS_SESSION_TOKEN'] ?? null);
+        }
     }
 }


### PR DESCRIPTION
The config filled by `ensureDynamoDbIsConfigured()` and `ensureSqsIsConfigured()` is missing session token. These config will only be filled if people don't have perspective config set in their own project. 

related to laravel/laravel#5138
related post on laracasts:
https://laracasts.com/discuss/channels/general-discussion/laravel-moving-app-to-vapor-unrecognizedclientexception

I haven't come up with an elegant way to do this, feel free to change it if you have a better idea.

P.S. Although [this comment from taylor](https://github.com/laravel/laravel/pull/5138#issuecomment-541666140) says that Vapor are "removing the AWS credentials from people's configuration files on deployment" but seems like it is not removing anything...