### PR TITLE
Improve assertions

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,4 +2,3 @@ preset: laravel
 
 disabled:
   - single_class_element_per_statement
-  - self_accessor

--- a/tests/Feature/SignedStorageUrlControllerTest.php
+++ b/tests/Feature/SignedStorageUrlControllerTest.php
@@ -3,14 +3,14 @@
 namespace Laravel\Vapor\Tests\Feature;
 
 use GuzzleHttp\Client;
+use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
+use Illuminate\Support\Facades\Gate;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Support\Facades\Gate;
-use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 
 class SignedStorageUrlControllerTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -34,11 +34,11 @@ class SignedStorageUrlControllerTest extends TestCase
         $response = $this->withoutExceptionHandling()->json('POST', '/vapor/signed-storage-url?content_type=text/plain');
 
         $response->assertStatus(201);
-        $this->assertTrue(is_string($response->original['uuid']));
-        $this->assertTrue(is_string($response->original['key']));
-        $this->assertTrue(is_string($response->original['url']));
-        $this->assertTrue(is_array($response->original['headers']));
-        $this->assertEquals('text/plain', $response->original['headers']['Content-Type']);
+        $this->assertIsString($response->original['uuid']);
+        $this->assertIsString($response->original['key']);
+        $this->assertIsString($response->original['url']);
+        $this->assertIsArray($response->original['headers']);
+        $this->assertSame('text/plain', $response->original['headers']['Content-Type']);
 
         // $url = $response->original['url'];
         // $headers = $response->original['headers'];
@@ -61,7 +61,6 @@ class SignedStorageUrlControllerTest extends TestCase
         $this->assertStringContainsString('laravel-s3-test-1.custom-url', $response->original['url']);
     }
 
-
     public function test_cant_retrieve_signed_urls_without_proper_environment_variables()
     {
         Gate::define('uploadFiles', function ($user = null, $bucket) {
@@ -76,7 +75,6 @@ class SignedStorageUrlControllerTest extends TestCase
         $response = $this->withoutExceptionHandling()->json('POST', '/vapor/signed-storage-url');
     }
 
-
     public function test_cant_retrieve_signed_urls_if_not_authenticated()
     {
         Gate::define('uploadFiles', function ($user, $bucket) {
@@ -88,7 +86,6 @@ class SignedStorageUrlControllerTest extends TestCase
         $response->assertStatus(403);
     }
 
-
     public function test_cant_retrieve_signed_urls_if_not_authorized()
     {
         Gate::define('uploadFiles', function ($user = null, $bucket) {
@@ -99,7 +96,6 @@ class SignedStorageUrlControllerTest extends TestCase
 
         $response->assertStatus(403);
     }
-
 
     /**
      * Get the package providers.

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -2,17 +2,16 @@
 
 namespace Laravel\Vapor\Tests\Unit;
 
+use Laravel\Vapor\Runtime\Fpm\FpmRequest;
 use Mockery;
 use PHPUnit\Framework\TestCase;
-use Laravel\Vapor\Runtime\Fpm\FpmRequest;
 
 class FpmRequestTest extends TestCase
 {
-    public function tearDown() : void
+    protected function tearDown(): void
     {
         Mockery::close();
     }
-
 
     public function test_query_string_is_decoded_for_elb_requests()
     {
@@ -26,7 +25,7 @@ class FpmRequestTest extends TestCase
             ],
         ], 'index.php');
 
-        $this->assertEquals(http_build_query(['Host' => urldecode($host)]), $request->serverVariables['QUERY_STRING']);
+        $this->assertSame(http_build_query(['Host' => urldecode($host)]), $request->serverVariables['QUERY_STRING']);
     }
 
     public function test_api_gateway_headers_are_handled()
@@ -42,7 +41,7 @@ class FpmRequestTest extends TestCase
                 'X-Amzn-Trace-Id' => $trace,
                 'X-Forwarded-For' => $for,
                 'X-Forwarded-Port' => $port,
-                'X-Forwarded-Proto' => $port
+                'X-Forwarded-Proto' => $port,
             ],
             'multiValueHeaders' => [
                 'X-Amzn-Trace-Id' => [
@@ -62,10 +61,10 @@ class FpmRequestTest extends TestCase
             'multiValueQueryStringParameters' => null,
         ], 'index.php');
 
-        $this->assertEquals($trace, $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
-        $this->assertEquals($for, $request->serverVariables['HTTP_X_FORWARDED_FOR']);
-        $this->assertEquals($port, $request->serverVariables['HTTP_X_FORWARDED_PORT']);
-        $this->assertEquals($proto, $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
+        $this->assertSame($trace, $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
+        $this->assertSame($for, $request->serverVariables['HTTP_X_FORWARDED_FOR']);
+        $this->assertSame($port, $request->serverVariables['HTTP_X_FORWARDED_PORT']);
+        $this->assertSame($proto, $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
     }
 
     public function test_load_balancer_headers_are_over_spoofed_headers()
@@ -98,9 +97,9 @@ class FpmRequestTest extends TestCase
             ],
         ], 'index.php');
 
-        $this->assertEquals($trace, $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
-        $this->assertEquals($for, $request->serverVariables['HTTP_X_FORWARDED_FOR']);
-        $this->assertEquals($port, $request->serverVariables['HTTP_X_FORWARDED_PORT']);
-        $this->assertEquals($proto, $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
+        $this->assertSame($trace, $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
+        $this->assertSame($for, $request->serverVariables['HTTP_X_FORWARDED_FOR']);
+        $this->assertSame($port, $request->serverVariables['HTTP_X_FORWARDED_PORT']);
+        $this->assertSame($proto, $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
     }
 }

--- a/tests/Unit/HttpKernelTest.php
+++ b/tests/Unit/HttpKernelTest.php
@@ -2,16 +2,16 @@
 
 namespace Laravel\Vapor\Tests\Unit;
 
-use Laravel\Vapor\Runtime\Http\Middleware\EnsureBinaryEncoding;
-use Mockery;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use PHPUnit\Framework\TestCase;
+use Laravel\Vapor\Runtime\Http\Middleware\EnsureBinaryEncoding;
 use Laravel\Vapor\Runtime\HttpKernel;
+use Mockery;
+use PHPUnit\Framework\TestCase;
 
 class HttpKernelTest extends TestCase
 {
-    public function tearDown() : void
+    protected function tearDown(): void
     {
         Mockery::close();
     }
@@ -30,7 +30,6 @@ class HttpKernelTest extends TestCase
 
         // $this->assertEquals($mockResponse, $response);
     }
-
 
     public function test_should_send_maintenance_mode_response_when_enabled_and_on_non_vanity_domain()
     {
@@ -52,17 +51,17 @@ class HttpKernelTest extends TestCase
         $response = new Response('ok', 200);
         $this->assertFalse(EnsureBinaryEncoding::isBase64EncodingRequired($response));
 
-        $response = new Response("{}", 200, [
+        $response = new Response('{}', 200, [
             'Content-Type' => 'application/json',
         ]);
         $this->assertFalse(EnsureBinaryEncoding::isBase64EncodingRequired($response));
 
-        $response = new Response("{}", 200, [
+        $response = new Response('{}', 200, [
             'Content-Type' => 'application/vnd.api+json; charset=UTF-8',
         ]);
         $this->assertFalse(EnsureBinaryEncoding::isBase64EncodingRequired($response));
 
-        $response = new Response("*", 200, [
+        $response = new Response('*', 200, [
             'Content-Type' => 'application/octet-stream',
         ]);
         $this->assertTrue(EnsureBinaryEncoding::isBase64EncodingRequired($response));

--- a/tests/Unit/VaporJobTest.php
+++ b/tests/Unit/VaporJobTest.php
@@ -2,20 +2,19 @@
 
 namespace Laravel\Vapor\Tests\Unit;
 
-use Mockery;
 use Aws\Sqs\SqsClient;
-use PHPUnit\Framework\TestCase;
-use Laravel\Vapor\Queue\VaporJob;
 use Illuminate\Container\Container;
 use Laravel\Vapor\Queue\VaporConnector;
+use Laravel\Vapor\Queue\VaporJob;
+use Mockery;
+use PHPUnit\Framework\TestCase;
 
 class VaporJobTest extends TestCase
 {
-    public function tearDown() : void
+    protected function tearDown(): void
     {
         Mockery::close();
     }
-
 
     /**
      * @doesNotPerformAssertions
@@ -43,7 +42,6 @@ class VaporJobTest extends TestCase
         $job->release();
     }
 
-
     public function test_can_determine_job_attempts()
     {
         $client = (new VaporConnector)->connect([
@@ -59,6 +57,6 @@ class VaporJobTest extends TestCase
             'Body' => json_encode(['attempts' => 1]),
         ], 'sqs', 'test-vapor-queue-url');
 
-        $this->assertEquals(2, $job->attempts());
+        $this->assertSame(2, $job->attempts());
     }
 }

--- a/tests/Unit/VaporQueueTest.php
+++ b/tests/Unit/VaporQueueTest.php
@@ -2,14 +2,14 @@
 
 namespace Laravel\Vapor\Tests\Unit;
 
-use Mockery;
 use Aws\Sqs\SqsClient;
-use PHPUnit\Framework\TestCase;
 use Laravel\Vapor\Queue\VaporQueue;
+use Mockery;
+use PHPUnit\Framework\TestCase;
 
 class VaporQueueTest extends TestCase
 {
-    public function tearDown() : void
+    protected function tearDown(): void
     {
         Mockery::close();
     }
@@ -20,10 +20,10 @@ class VaporQueueTest extends TestCase
 
         $job = new FakeJob;
 
-        $sqs->shouldReceive('sendMessage')->once()->with(Mockery::on(function($argument) use ($job) {
+        $sqs->shouldReceive('sendMessage')->once()->with(Mockery::on(function ($argument) use ($job) {
             $messageBody = json_decode($argument['MessageBody'], true);
 
-            $this->assertEquals('/test-vapor-queue-url', $argument['QueueUrl']);
+            $this->assertSame('/test-vapor-queue-url', $argument['QueueUrl']);
             $this->assertArraySubset([
                 'displayName' => FakeJob::class,
                 'job' => 'Illuminate\Queue\CallQueuedHandler@call',
@@ -37,12 +37,12 @@ class VaporQueueTest extends TestCase
             ], $messageBody);
 
             return true;
-        }))->andReturnSelf(); 
+        }))->andReturnSelf();
 
         $sqs->shouldReceive('get')->andReturn('attribute-value');
 
         $queue = new VaporQueue($sqs, 'test-vapor-queue-url');
 
-        $this->assertEquals('attribute-value', $queue->push($job));
+        $this->assertSame('attribute-value', $queue->push($job));
     }
 }

--- a/tests/Unit/VaporWorkCommandTest.php
+++ b/tests/Unit/VaporWorkCommandTest.php
@@ -7,11 +7,10 @@ use Orchestra\Testbench\TestCase;
 
 class VaporWorkCommandTest extends TestCase
 {
-    public function tearDown() : void
+    protected function tearDown(): void
     {
         Mockery::close();
     }
-
 
     public function test_command_can_be_called()
     {


### PR DESCRIPTION
# Changed log

- Using the `assertIsString` to assert result type is `string`.
- Using the `assertIsArray` to assert result type is `array`.
- Using the `assertSame` to replace `assertEquals` and it can make assertion equals checking strict.
- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void` and `protected function tearDown(): void` methods.