### PR TITLE
Fixes usage of queue options with Laravel 8

### DIFF
--- a/src/Console/Commands/VaporWorkCommand.php
+++ b/src/Console/Commands/VaporWorkCommand.php
@@ -166,12 +166,18 @@ class VaporWorkCommand extends Command
      */
     protected function gatherWorkerOptions()
     {
-        return new WorkerOptions(
+        $options = [
             $this->option('delay'), $memory = 512,
             $this->option('timeout'), $sleep = 0,
             $this->option('tries'), $this->option('force'),
-            $stopWhenEmpty = false
-        );
+            $stopWhenEmpty = false,
+        ];
+
+        if (property_exists(WorkerOptions::class, 'name')) {
+            $options = array_merge(['default'], $options);
+        }
+
+        return new WorkerOptions(...$options);
     }
 
     /**


### PR DESCRIPTION
This pull request fixes the usage of the `QueueOptions` class while using Laravel 8 with `vapor-core`.

Before the fix, this is the options used:
```json
{
    "name": "3",
    "backoff": 512,
    "memory": "59",
    "timeout": 0,
    "sleep": "3",
    "maxTries": false,
    "force": false,
    "stopWhenEmpty": false,
    "maxJobs": 0,
    "maxTime": 0
},
```

Because `"maxTries": false` is equal to `false` instead of `0`, this causes jobs to be retried forever in the queue.

After the fix:
```json
{
    "name": "default",
    "backoff": "3",
    "memory": 512,
    "timeout": "59",
    "sleep": 0,
    "maxTries": "3",
    "force": false,
    "stopWhenEmpty": false,
    "maxJobs": 0,
    "maxTime": 0
}
```