### PR TITLE
Allow custom trustedproxy.proxies config

### DIFF
--- a/src/VaporServiceProvider.php
+++ b/src/VaporServiceProvider.php
@@ -122,7 +122,7 @@ class VaporServiceProvider extends ServiceProvider
      */
     private function configureTrustedProxy()
     {
-        Config::set('trustedproxy.proxies', ['0.0.0.0/0', '2000:0:0:0:0:0:0:0/3']);
+        Config::set('trustedproxy.proxies', Config::get('trustedproxy.proxies') ?? ['0.0.0.0/0', '2000:0:0:0:0:0:0:0/3']);
     }
 
     /**


### PR DESCRIPTION
Currenltly the vapor-core overrides the `trustedproxy.proxies` config we'd ideally like to be able to configure this value.

This pull request will leave the configuration as it is if it has been modified from the default value (`null`).