### PR TITLE
Adds the possibility of serving assets from application's domain

### DIFF
--- a/config/vapor.php
+++ b/config/vapor.php
@@ -28,4 +28,18 @@ return [
 
     'redirect_robots_txt' => true,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Serve Assets
+    |--------------------------------------------------------------------------
+    |
+    | Here you can configure list of public assets that should be
+    | served directly from your application's "domain" instead
+    | of the S3 asset bucket or the CloudFront's asset URL.
+    |
+    */
+    'serve_assets' => [
+        //
+    ],
+
 ];

--- a/src/Http/Middleware/ServeStaticAssets.php
+++ b/src/Http/Middleware/ServeStaticAssets.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Laravel\Vapor\Http\Middleware;
+
+use Closure;
+use GuzzleHttp\Client;
+
+class ServeStaticAssets
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string|null  ...$guards
+     * @return mixed
+     */
+    public function handle($request, Closure $next, ...$guards)
+    {
+        $response = $next($request);
+
+        if (isset($_ENV['VAPOR_SSM_PATH']) && $response->getStatusCode() === 404) {
+            $requestUri = $request->getRequestUri();
+
+            if (in_array(ltrim($requestUri, '/'), config('vapor.serve_assets', [])) !== false) {
+                $asset = (new Client)->get(asset($requestUri));
+
+                $headers = collect($asset->getHeaders())
+                    ->only(['Content-Length', 'Content-Type'])
+                    ->all();
+
+                if ($asset->getStatusCode() === 200) {
+                    return response($asset->getBody())->withHeaders($headers);
+                }
+            }
+        }
+
+        return $response;
+    }
+}

--- a/src/VaporServiceProvider.php
+++ b/src/VaporServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Vapor;
 
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
@@ -10,6 +11,7 @@ use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
 use Laravel\Vapor\Console\Commands\VaporWorkCommand;
 use Laravel\Vapor\Http\Controllers\SignedStorageUrlController;
+use Laravel\Vapor\Http\Middleware\ServeStaticAssets;
 use Laravel\Vapor\Queue\VaporConnector;
 
 class VaporServiceProvider extends ServiceProvider
@@ -75,6 +77,7 @@ class VaporServiceProvider extends ServiceProvider
         $this->configureTrustedProxy();
 
         $this->registerCommands();
+        $this->registerMiddleware();
     }
 
     /**
@@ -149,5 +152,16 @@ class VaporServiceProvider extends ServiceProvider
         });
 
         $this->commands(['command.vapor.work']);
+    }
+
+    /**
+     * Register the Vapor Http middleware.
+     *
+     * @return void
+     */
+    protected function registerMiddleware()
+    {
+        $this->app[HttpKernel::class]
+             ->pushMiddleware(ServeStaticAssets::class);
     }
 }


### PR DESCRIPTION
This pull request adds the possibility of serving assets from application's domain.

This is particular useful for developers deploying PWAs using Vapor, as they may want to serve assets directly from their domains such us: `your-domain.com/.well-known/assetlinks.json`, or `your-domain.com/serviceWorker.js`.

To get started, developers just need to populate they `serve_assets` key in the `config/vapor.php` file: 
```php
/*
|--------------------------------------------------------------------------
| Serve Assets
|--------------------------------------------------------------------------
|
| Here you can configure list of public assets that should be
| served directly from your application's "domain" instead
| of the S3 asset bucket or the CloudFront's asset URL.
|
*/
'serve_assets' => [
    '.well-known/assetlinks.json',
    'serviceWorker.js',
],
```

**Note**: It's only possible to serve dot files as assets once [this pull request](https://github.com/laravel/vapor-cli/pull/72) gets merged.