### PR TITLE
Sometimes attempts is undefined

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,4 +2,3 @@ preset: laravel
 
 disabled:
   - single_class_element_per_statement
-  - self_accessor

--- a/src/Queue/VaporJob.php
+++ b/src/Queue/VaporJob.php
@@ -18,7 +18,7 @@ class VaporJob extends SqsJob
 
         $payload = $this->payload();
 
-        $payload['attempts']++;
+        $payload['attempts'] = ($payload['attempts'] ?? 0) + 1;
 
         $this->sqs->deleteMessage([
             'QueueUrl' => $this->queue,
@@ -39,6 +39,6 @@ class VaporJob extends SqsJob
      */
     public function attempts()
     {
-        return ($this->payload()['attempts'] ?? null) + 1;
+        return ($this->payload()['attempts'] ?? 0) + 1;
     }
 }


### PR DESCRIPTION
Hi,

I've encountered a scenario where it gets to this code and `attempts` is not defined on the job.

Packages I'm using that might have contributed to this are:

- shiftonelabs/laravel-sqs-fifo-queue
- spatie/laravel-rate-limited-job-middleware

While researching the issue, I saw this code, which I think could do with a fix.

1. The first fix covers the case when it's not defined.
2. The second fix changes the fallback value to be 0 rather than null, since we want an int.
   This is not directly related to the error, but it could have played a part.

```
{
    "message": "Undefined index: attempts",
    "context": {
        "exception": {
            "class": "ErrorException",
            "message": "Undefined index: attempts",
            "code": 0,
            "file": "/var/task/vendor/laravel/vapor-core/src/Queue/VaporJob.php:21"
        },
        "aws_request_id": "4ff603f4-1f96-5f3c-bc64-54190b920a8d"
    },
    "level": 400,
    "level_name": "ERROR",
    "channel": "staging",
    "datetime": "2020-09-29T10:51:59.029938+00:00",
    "extra": {}
}
```

EDIT: Added a change to the styleci config. It was throwing an error about not being able to disable the setting (cos it's not enabled).