### PR TITLE
Fixes missing attemps key

### DIFF
--- a/src/Queue/VaporJob.php
+++ b/src/Queue/VaporJob.php
@@ -18,7 +18,7 @@ class VaporJob extends SqsJob
 
         $payload = $this->payload();
 
-        $payload['attempts']++;
+        $payload['attempts'] = ($payload['attempts'] ?? 0) + 1;
 
         $this->sqs->deleteMessage([
             'QueueUrl' => $this->queue,
@@ -39,6 +39,6 @@ class VaporJob extends SqsJob
      */
     public function attempts()
     {
-        return ($this->payload()['attempts'] ?? null) + 1;
+        return ($this->payload()['attempts'] ?? 0) + 1;
     }
 }

--- a/tests/Unit/VaporJobTest.php
+++ b/tests/Unit/VaporJobTest.php
@@ -59,4 +59,22 @@ class VaporJobTest extends TestCase
 
         $this->assertSame(2, $job->attempts());
     }
+
+    public function test_handles_job_missing_attempts()
+    {
+        $client = (new VaporConnector)->connect([
+            'driver' => 'sqs',
+            'key' => 'test-key',
+            'secret' => 'test-secret',
+            'prefix' => 'https://sqs.us-east-1.amazonaws.com/111111111',
+            'queue' => 'test-queue',
+            'region' => 'us-east-1',
+        ]);
+
+        $job = new VaporJob(new Container, $client->getSqs(), [
+            'Body' => json_encode([]),
+        ], 'sqs', 'test-vapor-queue-url');
+
+        $this->assertSame(1, $job->attempts());
+    }
 }


### PR DESCRIPTION
This pull request ports https://github.com/laravel/vapor-core/pull/63 to the `2.0` branch.