### PR TITLE
Adds support to PHP 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
         laravel: [^6.0, ^7.0, ^8.0]
         exclude:
           - php: 7.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,17 +37,10 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      - name: Install PHP 7 dependencies
+      - name: Install PHP dependencies
         run: |
            composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
            composer update --prefer-dist --no-interaction --no-progress
-        if: "matrix.php < 8"
-
-      - name: Install PHP 8 dependencies
-        run: |
-           composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
-           composer update --prefer-dist --no-interaction --no-progress
-        if: "matrix.php >= 8"
 
       - name: Execute unit tests
         run: vendor/bin/phpunit --testsuite=Unit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Install PHP 8 dependencies
         run: |
-           composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update --ignore-platform-req=php
-           composer update --prefer-dist --no-interaction --no-progress --ignore-platform-req=php
+           composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
+           composer update --prefer-dist --no-interaction --no-progress
         if: "matrix.php >= 8"
 
       - name: Execute unit tests

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "aws/aws-sdk-php": "^3.80",
         "guzzlehttp/guzzle": "^6.3|^7.0",
         "hollodotme/fast-cgi-client": "^3.0",
@@ -31,7 +31,7 @@
     "require-dev": {
         "mockery/mockery": "^1.2",
         "orchestra/testbench": "^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Feature/SignedStorageUrlControllerTest.php
+++ b/tests/Feature/SignedStorageUrlControllerTest.php
@@ -27,7 +27,7 @@ class SignedStorageUrlControllerTest extends TestCase
 
     public function test_controller_returns_signed_urls()
     {
-        Gate::define('uploadFiles', function ($user = null, $bucket) {
+        Gate::define('uploadFiles', function ($user = null, $bucket = null) {
             return true;
         });
 
@@ -52,7 +52,7 @@ class SignedStorageUrlControllerTest extends TestCase
     public function test_aws_url_environmental_variable_is_used()
     {
         $_ENV['AWS_URL'] = 'http://custom-url';
-        Gate::define('uploadFiles', function ($user = null, $bucket) {
+        Gate::define('uploadFiles', function ($user = null, $bucket = null) {
             return true;
         });
 
@@ -63,7 +63,7 @@ class SignedStorageUrlControllerTest extends TestCase
 
     public function test_cant_retrieve_signed_urls_without_proper_environment_variables()
     {
-        Gate::define('uploadFiles', function ($user = null, $bucket) {
+        Gate::define('uploadFiles', function ($user = null, $bucket = null) {
             return true;
         });
 
@@ -88,7 +88,7 @@ class SignedStorageUrlControllerTest extends TestCase
 
     public function test_cant_retrieve_signed_urls_if_not_authorized()
     {
-        Gate::define('uploadFiles', function ($user = null, $bucket) {
+        Gate::define('uploadFiles', function ($user = null, $bucket = null) {
             return false;
         });
 

--- a/tests/Unit/HttpKernelTest.php
+++ b/tests/Unit/HttpKernelTest.php
@@ -16,21 +16,6 @@ class HttpKernelTest extends TestCase
         Mockery::close();
     }
 
-    public function test_request_can_be_handled()
-    {
-        // $app = Mockery::mock('Illuminate\Foundation\Application');
-
-        // $app->shouldReceive('useStoragePath')->once()->with('/tmp/storage');
-        // $app->shouldReceive('storagePath')->andReturn('/tmp/storage');
-        // $app->shouldReceive('handle')->andReturn($mockResponse = new Response('Hello World'));
-        // $app->shouldReceive('terminate')->once();
-
-        // $handler = new HttpKernel($app);
-        // $response = $handler->handle(Request::create('/', 'GET'));
-
-        // $this->assertEquals($mockResponse, $response);
-    }
-
     public function test_should_send_maintenance_mode_response_when_enabled_and_on_non_vanity_domain()
     {
         $_ENV['APP_VANITY_URL'] = 'https://something.com';

--- a/tests/Unit/VaporQueueTest.php
+++ b/tests/Unit/VaporQueueTest.php
@@ -24,7 +24,8 @@ class VaporQueueTest extends TestCase
             $messageBody = json_decode($argument['MessageBody'], true);
 
             $this->assertSame('/test-vapor-queue-url', $argument['QueueUrl']);
-            $this->assertArraySubset([
+
+            $subset = [
                 'displayName' => FakeJob::class,
                 'job' => 'Illuminate\Queue\CallQueuedHandler@call',
                 'maxTries' => null,
@@ -34,7 +35,12 @@ class VaporQueueTest extends TestCase
                     'command' => serialize($job),
                 ],
                 'attempts' => 0,
-            ], $messageBody);
+            ];
+
+            foreach ($subset as $key => $value) {
+                $this->assertArrayHasKey($key, $messageBody);
+                $this->assertSame($value, $messageBody[$key]);
+            }
 
             return true;
         }))->andReturnSelf();


### PR DESCRIPTION
This pull request makes `vapor-core` support PHP 8.

Todo/Requirements:

- [x] Laravel Framework PHP 8 support: https://github.com/laravel/framework/pull/33388.
- [x] Re-test this pull request once all requirements are meet.