### PR TITLE
Activate maintenance mode in CLI

### DIFF
--- a/stubs/cliRuntime.php
+++ b/stubs/cliRuntime.php
@@ -40,6 +40,11 @@ with(require __DIR__.'/bootstrap/app.php', function ($app) {
 
     $app->useStoragePath(StorageDirectories::PATH);
 
+    if (isset($_ENV['VAPOR_MAINTENANCE_MODE']) &&
+        $_ENV['VAPOR_MAINTENANCE_MODE'] === 'true') {
+        file_put_contents($app->storagePath().'/framework/down', '[]');
+    }
+
     echo 'Caching Laravel configuration'.PHP_EOL;
 
     try {


### PR DESCRIPTION
Rightnow maintenance mode is not respected when running CLI commands or the queue. This PR fixes this by detecting vapor maintenance mode and creating a `/framework/down` file that's used by the framework to check if the app is down for maintenance.

With this PR, queued jobs and scheduled commands won't run if the app is in maintenance mode.