### PR TITLE
Allow redis database to be configured

### DIFF
--- a/src/ConfiguresRedis.php
+++ b/src/ConfiguresRedis.php
@@ -28,7 +28,7 @@ trait ConfiguresRedis
                         'host' => $_ENV['REDIS_HOST'] ?? '127.0.0.1',
                         'password' => null,
                         'port' => 6379,
-                        'database' => 0,
+                        'database' => $_ENV['REDIS_DB'] ?? 0,
                     ],
                 ],
                 'cache' => [
@@ -36,7 +36,7 @@ trait ConfiguresRedis
                         'host' => $_ENV['REDIS_HOST'] ?? '127.0.0.1',
                         'password' => null,
                         'port' => 6379,
-                        'database' => 0,
+                        'database' => $_ENV['REDIS_CACHE_DB'] ?? 0,
                     ],
                 ],
             ]),


### PR DESCRIPTION
**TL;DR**
If you have multiple applications deployed with vapor all using the same redis instance and run `artisan cache:clear` then it clears the cache for all applications.  If there is a specific reason to configure it this way then I am sorry for creating this. It would be great if you could let me know the reason before closing. 

Fix: Allow redis default and cache databases to be configured per environment using same environment variables that are in default laravel.

**Problem**
In an effort to reduce costs we put all our test & staging applications in the same AWS account using the same RDS and redis cache instances. Our SESSION_DRIVER is set to using redis. We have noticed that after running `artisan cache:clear` on one application it was logging out anyone using the other applications.

I did some investigating and initially added unique REDIS_DB and REDIS_CACHE_DB environment variables to each of the environments but then found that they were not being applied and are overridden by the below code. 

**Cause**
It is hardcoded to `0` for both the 'default' and 'cache' connections:
https://github.com/laravel/vapor-core/blob/5b03dd3994128684053c0c56a6c78c941fcc98f4/src/ConfiguresRedis.php#L25-L42

In a default laravel installation the database number config is customisable per environment:
https://github.com/laravel/laravel/blob/8.x/config/database.php#L129
```php
'default' => [
    // ...
    'database' => env('REDIS_DB', 0),
],

'cache' => [
   // ...
    'database' => env('REDIS_CACHE_DB', 1),
],
```

**Solution**
Add back use of REDIS_DB and REDIS_CACHE_DB to the overridden config. 

Also should both `default` and `cache` connections be set to have the same `database` value? In the above code both are hardcoded to zero. However in the default laravel config the `cache` connection defaults to `1`. 