### PR TITLE
Adds the possibility of using AL2 with separate-vendor option

### DIFF
--- a/stubs/runtime-with-vendor-download.php
+++ b/stubs/runtime-with-vendor-download.php
@@ -24,7 +24,18 @@ $appRoot = $_ENV['LAMBDA_TASK_ROOT'];
 if (! file_exists('/tmp/vendor')) {
     fwrite(STDERR, 'Downloading the application vendor archive...'.PHP_EOL);
 
-    exec(sprintf('/opt/awscli/aws s3 cp s3://%s/%s-vendor.zip /tmp/vendor.zip',
+    $envs = '';
+
+    if (is_dir('/opt/awscli/lib/python2.7')) {
+        $envs = sprintf('LD_LIBRARY_PATH="%s" PYTHONHOME="%s" PYTHONPATH="%s"',
+            '/opt/awscli/lib',
+            '/opt/awscli/lib/python2.7',
+            '/opt/awscli/lib/python2.7:/opt/awscli/lib/python2.7/lib-dynload'
+        );
+    }
+
+    exec(sprintf('%s /opt/awscli/aws s3 cp s3://%s/%s-vendor.zip /tmp/vendor.zip',
+        $envs,
         $_ENV['VAPOR_ARTIFACT_BUCKET_NAME'],
         $_ENV['VAPOR_ARTIFACT_NAME']
     ));


### PR DESCRIPTION
This pull request adds the possibility of AL2 be used with the separate-vendor option.

In the AWSCLI layer for AL2, we actually install a few extra dependencies specifically for `awscli`. In this pull request, we instruct the `awscli` binary to use them.