### PR TITLE
Remove padding from base64_encode output

### DIFF
--- a/src/Runtime/Handlers/QueueHandler.php
+++ b/src/Runtime/Handlers/QueueHandler.php
@@ -53,7 +53,7 @@ class QueueHandler implements LambdaEventHandler
             $consoleKernel = static::$app->make(Kernel::class);
 
             $consoleInput = new StringInput(
-                'vapor:work '.base64_encode(json_encode($event['Records'][0])).' '.$commandOptions.' --no-interaction'
+                'vapor:work '.rtrim(base64_encode(json_encode($event['Records'][0])), '=').' '.$commandOptions.' --no-interaction'
             );
 
             $consoleKernel->terminate($consoleInput, $status = $consoleKernel->handle(


### PR DESCRIPTION
`base64_encode ()` may contain one or two `=` symbols in the output for padding. These are not needed when doing `base64_decode()` but when fed to the symfony process component, it'll try to escape those special characters using `escapeshellarg()`. This PHP function has a limit and produces the following error:

```
Argument exceeds the allowed length of 131072 bytes
```

Simplest solution is to just trim the `=`s.