### PR TITLE
Update signed-storage middleware to be configurable

### DIFF
--- a/config/vapor.php
+++ b/config/vapor.php
@@ -43,4 +43,18 @@ return [
         //
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Vapor Route Middleware
+    |--------------------------------------------------------------------------
+    |
+    | These middleware will be assigned to the route used to
+    | create signed S3 storage urls.
+    |
+    */
+
+    'middleware' => [
+        'web',
+    ],
+
 ];

--- a/config/vapor.php
+++ b/config/vapor.php
@@ -43,18 +43,4 @@ return [
         //
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Vapor Route Middleware
-    |--------------------------------------------------------------------------
-    |
-    | These middleware will be assigned to the route used to
-    | create signed S3 storage urls.
-    |
-    */
-
-    'middleware' => [
-        'web',
-    ],
-
 ];

--- a/src/DefinesRoutes.php
+++ b/src/DefinesRoutes.php
@@ -20,6 +20,6 @@ trait DefinesRoutes
         Route::post(
             '/vapor/signed-storage-url',
             Contracts\SignedStorageUrlController::class.'@store'
-        )->middleware('web');
+        )->middleware(config('vapor.middleware', 'web'));
     }
 }


### PR DESCRIPTION
What?
The signed-storage route's middleware name is currently hard-coded and doesn't allow for customization.

How?
This PR adds a new config entry to change that in just a few lines.

Why?
Currently, you can not use the signed-storage feature via stateless requests such as using an auth token provided by e.g. Laravel Sanctum.

Let me know if this needs any changes or another target branch.

Cheers,
Micha