### PR TITLE
SignedStorageUrlController: Return full URI including schema and port

### DIFF
--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -42,7 +42,7 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
             'uuid' => $uuid,
             'bucket' => $bucket,
             'key' => $key,
-            'url' => $uri,
+            'url' => $uri->__toString(),
             'headers' => $this->headers($request, $signedRequest),
         ], 201);
     }

--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -42,7 +42,7 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
             'uuid' => $uuid,
             'bucket' => $bucket,
             'key' => $key,
-            'url' => 'https://'.$uri->getHost().$uri->getPath().'?'.$uri->getQuery(),
+            'url' => $uri,
             'headers' => $this->headers($request, $signedRequest),
         ], 201);
     }


### PR DESCRIPTION
This PR proposes a small change that I came across when setting up a local MinIO instance to test the storage feature.

I changed the returned URL to use the full URI returned by the `signedRequest`. I wondered if there was a reason behind hard coding the `https` / URL, that I do not see yet?
This allows using the controller in a testing environment and/or for a storage server with a different port, because it now includes both, the correct schema and port.

Thank you :rocket: 