### PR TITLE
Note for setting redirect_to_root to null

### DIFF
--- a/config/vapor.php
+++ b/config/vapor.php
@@ -10,7 +10,8 @@ return [
     | When this option is enabled, Vapor will redirect requests to the "www"
     | subdomain to the application's root domain. When this option is not
     | enabled, Vapor redirects your root domain to the "www" subdomain.
-    | Setting this option to null will disable the redirect completely.
+    |
+    | Setting this option to null will disable all redirects.
     |
     */
 

--- a/config/vapor.php
+++ b/config/vapor.php
@@ -10,6 +10,7 @@ return [
     | When this option is enabled, Vapor will redirect requests to the "www"
     | subdomain to the application's root domain. When this option is not
     | enabled, Vapor redirects your root domain to the "www" subdomain.
+    | Setting this option to null will disable the redirect completely.
     |
     */
 


### PR DESCRIPTION
Additional notes to document change made in the commit below to hopefully save people some time. I was unaware that setting redirect_to_root to null would disable the redirect without inspecting the middleware and finding out the change made in the commit.

https://github.com/laravel/vapor-core/commit/9080b37c8b6379843651e05166f6fbb759bb252b