### PR TITLE
Implements the handling of API Gateway request context

### DIFF
--- a/src/Runtime/Fpm/FpmRequest.php
+++ b/src/Runtime/Fpm/FpmRequest.php
@@ -66,7 +66,7 @@ class FpmRequest implements ProvidesRequestData
             'SERVER_PORT' => $headers['x-forwarded-port'] ?? 80,
             'SERVER_PROTOCOL' => $event['requestContext']['protocol'] ?? 'HTTP/1.1',
             'SERVER_SOFTWARE' => 'vapor',
-            'LAMBDA_REQUEST_CONTEXT' => $event['requestContext'] ?? []
+            'LAMBDA_REQUEST_CONTEXT' => $event['requestContext'] ?? [],
         ]);
 
         [$headers, $serverVariables] = static::ensureContentTypeIsSet(

--- a/src/Runtime/Fpm/FpmRequest.php
+++ b/src/Runtime/Fpm/FpmRequest.php
@@ -66,6 +66,7 @@ class FpmRequest implements ProvidesRequestData
             'SERVER_PORT' => $headers['x-forwarded-port'] ?? 80,
             'SERVER_PROTOCOL' => $event['requestContext']['protocol'] ?? 'HTTP/1.1',
             'SERVER_SOFTWARE' => 'vapor',
+            'LAMBDA_REQUEST_CONTEXT' => $event['requestContext'] ?? []
         ]);
 
         [$headers, $serverVariables] = static::ensureContentTypeIsSet(

--- a/src/Runtime/Fpm/FpmRequest.php
+++ b/src/Runtime/Fpm/FpmRequest.php
@@ -54,6 +54,7 @@ class FpmRequest implements ProvidesRequestData
 
         $serverVariables = array_merge($serverVariables, [
             'GATEWAY_INTERFACE' => 'FastCGI/1.0',
+            'LAMBDA_REQUEST_CONTEXT' => $event['requestContext'] ?? [],
             'PATH_INFO' => $event['path'] ?? '/',
             'QUERY_STRING' => $queryString,
             'REMOTE_ADDR' => '127.0.0.1',
@@ -66,7 +67,6 @@ class FpmRequest implements ProvidesRequestData
             'SERVER_PORT' => $headers['x-forwarded-port'] ?? 80,
             'SERVER_PROTOCOL' => $event['requestContext']['protocol'] ?? 'HTTP/1.1',
             'SERVER_SOFTWARE' => 'vapor',
-            'LAMBDA_REQUEST_CONTEXT' => $event['requestContext'] ?? [],
         ]);
 
         [$headers, $serverVariables] = static::ensureContentTypeIsSet(

--- a/src/Runtime/Http/PsrRequestFactory.php
+++ b/src/Runtime/Http/PsrRequestFactory.php
@@ -77,7 +77,7 @@ class PsrRequestFactory
             'QUERY_STRING' => $queryString,
             'DOCUMENT_ROOT' => getcwd(),
             'REQUEST_URI' => $this->uri(),
-            'LAMBDA_REQUEST_CONTEXT' => $this->requestContext()
+            'LAMBDA_REQUEST_CONTEXT' => $this->requestContext(),
         ];
 
         if (isset($headers['Host'])) {
@@ -86,6 +86,7 @@ class PsrRequestFactory
 
         return $variables;
     }
+    
     /**
      * Get the request context for the event.
      *

--- a/src/Runtime/Http/PsrRequestFactory.php
+++ b/src/Runtime/Http/PsrRequestFactory.php
@@ -88,16 +88,6 @@ class PsrRequestFactory
     }
 
     /**
-     * Get the request context for the event.
-     *
-     * @return array
-     */
-    public function requestContext(): array
-    {
-        return $this->event['requestContext'] ?? [];
-    }
-
-    /**
      * Get the HTTP protocol version for the event.
      *
      * @return string
@@ -135,6 +125,16 @@ class PsrRequestFactory
     protected function queryString()
     {
         return http_build_query($this->event['queryStringParameters'] ?? []);
+    }
+
+    /**
+     * Get the request context for the event.
+     *
+     * @return array
+     */
+    public function requestContext(): array
+    {
+        return $this->event['requestContext'] ?? [];
     }
 
     /**

--- a/src/Runtime/Http/PsrRequestFactory.php
+++ b/src/Runtime/Http/PsrRequestFactory.php
@@ -77,6 +77,7 @@ class PsrRequestFactory
             'QUERY_STRING' => $queryString,
             'DOCUMENT_ROOT' => getcwd(),
             'REQUEST_URI' => $this->uri(),
+            'LAMBDA_REQUEST_CONTEXT' => $this->requestContext()
         ];
 
         if (isset($headers['Host'])) {
@@ -84,6 +85,15 @@ class PsrRequestFactory
         }
 
         return $variables;
+    }
+    /**
+     * Get the request context for the event.
+     *
+     * @return array
+     */
+    public function requestContext(): array
+    {
+        return $this->event['requestContext'] ?? [];
     }
 
     /**

--- a/src/Runtime/Http/PsrRequestFactory.php
+++ b/src/Runtime/Http/PsrRequestFactory.php
@@ -86,7 +86,7 @@ class PsrRequestFactory
 
         return $variables;
     }
-    
+
     /**
      * Get the request context for the event.
      *

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -27,7 +27,20 @@ class FpmRequestTest extends TestCase
 
         $this->assertSame(http_build_query(['Host' => urldecode($host)]), $request->serverVariables['QUERY_STRING']);
     }
-
+    
+    public function test_api_gateway_request_context_is_handled()
+    {
+        $request = FpmRequest::fromLambdaEvent([
+            'requestContext' => [
+                'accountId' =>  $accountId = '123'
+            ],
+            'httpMethod' => 'GET',
+            'multiValueQueryStringParameters' => [],
+            'multiValueHeaders' => []
+        ], 'index.php');
+        
+        $this->assertSame($accountId, $request->serverVariables['LAMBDA_REQUEST_CONTEXT']['accountId']);
+    }
     public function test_api_gateway_headers_are_handled()
     {
         $trace = 'Root=1-7696740c-c075312a25f21abe1ca19805;foobar';

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -32,15 +32,16 @@ class FpmRequestTest extends TestCase
     {
         $request = FpmRequest::fromLambdaEvent([
             'requestContext' => [
-                'accountId' =>  $accountId = '123'
+                'accountId' =>  $accountId = '123',
             ],
             'httpMethod' => 'GET',
             'multiValueQueryStringParameters' => [],
-            'multiValueHeaders' => []
+            'multiValueHeaders' => [],
         ], 'index.php');
         
         $this->assertSame($accountId, $request->serverVariables['LAMBDA_REQUEST_CONTEXT']['accountId']);
     }
+    
     public function test_api_gateway_headers_are_handled()
     {
         $trace = 'Root=1-7696740c-c075312a25f21abe1ca19805;foobar';

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -27,7 +27,7 @@ class FpmRequestTest extends TestCase
 
         $this->assertSame(http_build_query(['Host' => urldecode($host)]), $request->serverVariables['QUERY_STRING']);
     }
-    
+
     public function test_api_gateway_request_context_is_handled()
     {
         $request = FpmRequest::fromLambdaEvent([
@@ -38,10 +38,10 @@ class FpmRequestTest extends TestCase
             'multiValueQueryStringParameters' => [],
             'multiValueHeaders' => [],
         ], 'index.php');
-        
+
         $this->assertSame($accountId, $request->serverVariables['LAMBDA_REQUEST_CONTEXT']['accountId']);
     }
-    
+
     public function test_api_gateway_headers_are_handled()
     {
         $trace = 'Root=1-7696740c-c075312a25f21abe1ca19805;foobar';


### PR DESCRIPTION
Passes the request context to $_SERVER Global variable.
This allows the use of the context to achieve various things such as 
- Use the decoded JWT Token of cognito if Laravel app is behing a Cognito Authorizer
- Access various claims that may have been passed by an authorizer attached via API Gateway (lambda authorizer, OAuth, cognito)