### PR TITLE
 Implements the handling of API Gateway request context (fixed)

### DIFF
--- a/src/Runtime/Fpm/FpmRequest.php
+++ b/src/Runtime/Fpm/FpmRequest.php
@@ -52,7 +52,10 @@ class FpmRequest implements ProvidesRequestData
 
         $requestBody = static::getRequestBody($event);
 
-        $serverVariables = array_merge($serverVariables, [
+        $requestContext = static::getRequestContext($event);
+
+        $serverVariables = array_merge($serverVariables,
+            $requestContext, [
             'GATEWAY_INTERFACE' => 'FastCGI/1.0',
             'LAMBDA_REQUEST_CONTEXT' => $event['requestContext'] ?? [],
             'PATH_INFO' => $event['path'] ?? '/',
@@ -86,6 +89,22 @@ class FpmRequest implements ProvidesRequestData
         }
 
         return new static($serverVariables, $requestBody);
+    }
+    /**
+     * Get the Request Context from the given event
+     *
+     * @param  array  $event
+     * @return array
+     */
+    protected static function getRequestContext($event)
+    {
+        $requestContext = $event['requestContext'] ?? [];
+        $requestContext = Arr::dot($requestContext);
+
+        return array_combine(
+            array_map(function($k){ return 'REQUEST_CONTEXT.'.strtoupper($k); }, array_keys($requestContext)),
+            $requestContext
+        );
     }
 
     /**

--- a/src/Runtime/Http/PsrRequestFactory.php
+++ b/src/Runtime/Http/PsrRequestFactory.php
@@ -84,6 +84,8 @@ class PsrRequestFactory
             $variables['HTTP_HOST'] = $headers['Host'];
         }
 
+        $variables = array_merge($variables, $this->requestContext());
+
         return $variables;
     }
 
@@ -134,7 +136,13 @@ class PsrRequestFactory
      */
     public function requestContext(): array
     {
-        return $this->event['requestContext'] ?? [];
+        $requestContext = $this->event['requestContext'] ?? [];
+        $requestContext = Arr::dot($requestContext);
+
+        return array_combine(
+            array_map(function($k){ return 'REQUEST_CONTEXT.'.strtoupper($k); }, array_keys($requestContext)),
+            $requestContext
+        );
     }
 
     /**

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -39,7 +39,7 @@ class FpmRequestTest extends TestCase
             'multiValueHeaders' => [],
         ], 'index.php');
 
-        $this->assertSame($accountId, $request->serverVariables['LAMBDA_REQUEST_CONTEXT']['accountId']);
+        $this->assertSame($accountId, $request->serverVariables['REQUEST_CONTEXT.ACCOUNTID']);
     }
 
     public function test_api_gateway_headers_are_handled()


### PR DESCRIPTION
Fixes the error in pull 85 (https://github.com/laravel/vapor-core/pull/85)

- Flattening the requestContext array into a single dimension using Arr::dot()
- Merging the server variables with the flattened array of requestContext