### PR TITLE
Load secrets into $_SERVER

### DIFF
--- a/src/Runtime/Secrets.php
+++ b/src/Runtime/Secrets.php
@@ -25,6 +25,7 @@ class Secrets
                 echo "Injecting secret [{$key}] into runtime.".PHP_EOL;
 
                 $_ENV[$key] = $value;
+                $_SERVER[$key] = $value;
             }
         });
     }


### PR DESCRIPTION
When the PHP runtime starts, `$_SERVER` will be populated with variables from `$_ENV` before the vapor secrets injection happens.

If the a value was set for an environment key in the lambda configuration, `$_SERVER['KEY']` will take the value from `$_ENV['KEY']`. If a value was not set `$_SERVER['KEY']` will be undefined.

When secrets are injected, `$_ENV['KEY']` will be replaced by whatever value set for the secret.

Now when the `config:cache` command runs, the phpdotenv library will check the `$_SERVER` variable first before `$_ENV`. For a key that was set in the lambda configuration, `$_SERVER` will hold the original value of that key so that's what will be loaded into the application cached environment variables.

For a key that wasn't set in the lambda configuration, `$_SERVER` will not hold it so phpdotenv will read from `$_ENV` which will have the injected value from the secret.

The results is that keys set as an environment variable cannot be overriden by secrets.

This PR solves this issue.