### PR TITLE
Fix AWS_URL env variable misused

### DIFF
--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -130,6 +130,11 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
                 'token' => $_ENV['AWS_SESSION_TOKEN'] ?? null,
             ]);
 
+            if (array_key_exists('AWS_URL', $_ENV) && ! is_null($_ENV['AWS_URL'])) {
+                $config['url'] = $_ENV['AWS_URL'];
+                $config['endpoint'] = $_ENV['AWS_URL'];
+            }
+
             if (array_key_exists('AWS_ENDPOINT', $_ENV) && ! is_null($_ENV['AWS_ENDPOINT'])) {
                 $config['endpoint'] = $_ENV['AWS_ENDPOINT'];
             }

--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -130,9 +130,8 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
                 'token' => $_ENV['AWS_SESSION_TOKEN'] ?? null,
             ]);
 
-            if (array_key_exists('AWS_URL', $_ENV) && ! is_null($_ENV['AWS_URL'])) {
-                $config['url'] = $_ENV['AWS_URL'];
-                $config['endpoint'] = $_ENV['AWS_URL'];
+            if (array_key_exists('AWS_ENDPOINT', $_ENV) && ! is_null($_ENV['AWS_ENDPOINT'])) {
+                $config['endpoint'] = $_ENV['AWS_ENDPOINT'];
             }
         }
 


### PR DESCRIPTION
Hello,

I'm a Vapor customer and I try to put a cloudfront distribution in front of my S3 storage.
For Laravel to generate correct file url I need to set `AWS_URL` to the cloudfront url, but when I do that the file upload doesn't work anymore because `vapor-core` use that env variable to set the `endpoint` config. Following Laravel documentation it should use the `AWS_ENDPOINT` env variable instead. (https://laravel.com/docs/8.x/filesystem#amazon-s3-compatible-filesystems)

