### PR TITLE
[2.x] Avoids having `strings` as `content-length`

### DIFF
--- a/src/Runtime/Fpm/ActsAsFastCgiDataProvider.php
+++ b/src/Runtime/Fpm/ActsAsFastCgiDataProvider.php
@@ -97,7 +97,9 @@ trait ActsAsFastCgiDataProvider
      */
     public function getContentLength(): int
     {
-        return $this->serverVariables['CONTENT_LENGTH'] ?: 0;
+        $contentLength = $this->serverVariables['CONTENT_LENGTH'] ?: 0;
+
+        return is_numeric($contentLength) ? (int) $contentLength : 0;
     }
 
     /**

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -102,4 +102,43 @@ class FpmRequestTest extends TestCase
         $this->assertSame($port, $request->serverVariables['HTTP_X_FORWARDED_PORT']);
         $this->assertSame($proto, $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
     }
+
+    public function test_request_content_length_is_numeric()
+    {
+        $request = FpmRequest::fromLambdaEvent([
+            'httpMethod' => 'GET',
+            'headers' => [
+                // ..
+            ],
+        ], 'index.php');
+
+        $this->assertSame(0, $request->getContentLength());
+
+        $request = FpmRequest::fromLambdaEvent([
+            'httpMethod' => 'GET',
+            'headers' => [
+                'content-length' => 1,
+            ],
+        ], 'index.php');
+
+        $this->assertSame(1, $request->getContentLength());
+
+        $request = FpmRequest::fromLambdaEvent([
+            'httpMethod' => 'GET',
+            'headers' => [
+                'content-length' => '1',
+            ],
+        ], 'index.php');
+
+        $this->assertSame(1, $request->getContentLength());
+
+        $request = FpmRequest::fromLambdaEvent([
+            'httpMethod' => 'GET',
+            'headers' => [
+                'content-length' => 'foo',
+            ],
+        ], 'index.php');
+
+        $this->assertSame(0, $request->getContentLength());
+    }
 }


### PR DESCRIPTION
This pull request fixes the fact that - eventually - if someone sends a wrong `content-length`, Vapor will answer with a 502 as the `ActsAsFastCgiDataProvider.php::getContentLength` returns the following error: `Return value must be of type int, string returned `.