### PR TITLE
[feat] use secrets to hold dot env (.env) files, bypassing 2000 char limit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,11 @@
         "illuminate/queue": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
         "monolog/monolog": "^1.12|^2.0",
+        "nyholm/psr7": "^1.0",
         "riverline/multipart-parser": "^2.0",
         "symfony/process": "^4.3|^5.0",
-        "nyholm/psr7": "^1.0",
-        "symfony/psr-http-message-bridge": "^1.0|^2.0"
+        "symfony/psr-http-message-bridge": "^1.0|^2.0",
+        "vlucas/phpdotenv": "^5.3"
     },
     "require-dev": {
         "mockery/mockery": "^1.2",


### PR DESCRIPTION
Edit: See blog post for how to implement this in your app:
https://atymic.dev/blog/laravel-vapor-extended-secrets/

<hr>


Hey @nunomaduro 

This is a POC as discussed in the support ticket.

Basically, we've run out of our 2000 char limit and are going to 30+ more variables (lots of external providers)

This PR introduces the ability to create "Dot Env" secrets. These are secrets created in vapor, which when the application runs are parsed as ".env" files.

This gives us the ability to maintain a lot more env vars in one single secret, which makes updating our 4 environments much easier 

Feedback welcome :)