### PR TITLE
[2.x] Allows persisting database sessions between queue jobs

### DIFF
--- a/src/Console/Commands/WritesQueueEventMessages.php
+++ b/src/Console/Commands/WritesQueueEventMessages.php
@@ -35,7 +35,7 @@ trait WritesQueueEventMessages
      * Write the status output for the queue worker.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
-     * @param  string $status
+     * @param  string  $status
      * @return void
      */
     protected function writeOutput(Job $job, $status)

--- a/src/Runtime/Fpm/FpmRequest.php
+++ b/src/Runtime/Fpm/FpmRequest.php
@@ -110,7 +110,7 @@ class FpmRequest implements ProvidesRequestData
     /**
      * Get the query string from the event.
      *
-     * @param  array $event
+     * @param  array  $event
      * @return string
      */
     protected static function getQueryString(array $event)

--- a/src/Runtime/Handlers/CliHandler.php
+++ b/src/Runtime/Handlers/CliHandler.php
@@ -14,7 +14,7 @@ class CliHandler implements LambdaEventHandler
     /**
      * Handle an incoming Lambda event.
      *
-     * @param  array $event
+     * @param  array  $event
      * @param  \Laravel\Vapor\Contracts\LambdaResponse
      * @return ArrayLambdaResponse
      */

--- a/src/Runtime/Handlers/FpmHandler.php
+++ b/src/Runtime/Handlers/FpmHandler.php
@@ -13,7 +13,7 @@ class FpmHandler implements LambdaEventHandler
      * Handle an incoming Lambda event.
      *
      * @param  array  $event
-     * @return  \Laravel\Vapor\Contracts\LambdaResponse
+     * @return \Laravel\Vapor\Contracts\LambdaResponse
      */
     public function handle(array $event)
     {

--- a/src/Runtime/Handlers/QueueHandler.php
+++ b/src/Runtime/Handlers/QueueHandler.php
@@ -79,7 +79,7 @@ class QueueHandler implements LambdaEventHandler
      */
     protected function terminate()
     {
-        if (static::$app->resolved('db')) {
+        if (static::$app->resolved('db') && ! ($_ENV['VAPOR_QUEUE_DATABASE_SESSION_PERSIST'] ?? false)) {
             collect(static::$app->make('db')->getConnections())->each->disconnect();
         }
     }

--- a/src/Runtime/Handlers/QueueHandler.php
+++ b/src/Runtime/Handlers/QueueHandler.php
@@ -79,7 +79,7 @@ class QueueHandler implements LambdaEventHandler
      */
     protected function terminate()
     {
-        if (static::$app->resolved('db') && ($_ENV['VAPOR_QUEUE_DATABASE_PERSIST'] ?? false) !== 'true') {
+        if (static::$app->resolved('db') && ($_ENV['VAPOR_QUEUE_DATABASE_SESSION_PERSIST'] ?? false) !== 'true') {
             collect(static::$app->make('db')->getConnections())->each->disconnect();
         }
     }

--- a/src/Runtime/Handlers/QueueHandler.php
+++ b/src/Runtime/Handlers/QueueHandler.php
@@ -79,7 +79,7 @@ class QueueHandler implements LambdaEventHandler
      */
     protected function terminate()
     {
-        if (static::$app->resolved('db') && ! ($_ENV['VAPOR_QUEUE_DATABASE_SESSION_PERSIST'] ?? false)) {
+        if (static::$app->resolved('db') && ($_ENV['VAPOR_QUEUE_DATABASE_SESSION_PERSIST'] ?? false) !== 'true') {
             collect(static::$app->make('db')->getConnections())->each->disconnect();
         }
     }

--- a/src/Runtime/Handlers/QueueHandler.php
+++ b/src/Runtime/Handlers/QueueHandler.php
@@ -79,7 +79,7 @@ class QueueHandler implements LambdaEventHandler
      */
     protected function terminate()
     {
-        if (static::$app->resolved('db') && ($_ENV['VAPOR_QUEUE_DATABASE_SESSION_PERSIST'] ?? false) !== 'true') {
+        if (static::$app->resolved('db') && ($_ENV['VAPOR_QUEUE_DATABASE_PERSIST'] ?? false) !== 'true') {
             collect(static::$app->make('db')->getConnections())->each->disconnect();
         }
     }

--- a/src/VaporJobTimedOutException.php
+++ b/src/VaporJobTimedOutException.php
@@ -10,8 +10,8 @@ class VaporJobTimedOutException extends Exception
     /**
      * Create a new exception instance.
      *
-     * @param string $name
-     * @param Throwable|null $previous
+     * @param  string  $name
+     * @param  Throwable|null  $previous
      */
     public function __construct($name, Throwable $previous = null)
     {


### PR DESCRIPTION
This pull request allows persisting database sessions between queue jobs. To opt-in to this behavior, users simply need set the `VAPOR_QUEUE_DATABASE_SESSION_PERSIST` environment variable to `true`. Allowing to make a very simple job that uses the database at least once, up to 45% faster in a **512MB** lambda functions.

**Before:**
<img width="614" alt="Screenshot 2021-09-30 at 11 53 24" src="https://user-images.githubusercontent.com/5457236/135442970-c001a4a9-ee4a-4f6d-82aa-cda56b3ae762.png">

**After:**
<img width="603" alt="Screenshot 2021-09-30 at 11 56 18" src="https://user-images.githubusercontent.com/5457236/135442892-38051ffb-e0ec-4d3b-8165-1d4c29dcc7c0.png">

Things to keep in mind:

- This solution **was not stress-tested**: different database drivers, etc.
- I don't think we should document this option for now. Yet, I am alright with re-vising this topic later, taking some time to testing it, and possibly implement a TTL-like solution like the one we are doing for Vapor "Octane" integration.
- Once a lambda "queue" container uses a database connection, that database connection will remain open until the container gets destroyed. Normally, up to 5 minutes of "no usage" of a container.
- We should only offer this solution for users who have a ludicrous number of max database connections and know what they are doing.