### PR TITLE
[2.x] Fixes terminating container

### DIFF
--- a/src/Runtime/LambdaContainer.php
+++ b/src/Runtime/LambdaContainer.php
@@ -20,7 +20,10 @@ class LambdaContainer
         }
 
         if ($invocations >= $invocationLimit) {
-            Octane::terminate();
+
+            if (class_exists(\Laravel\Octane\Contracts\Client::class)) {
+                Octane::terminate();
+            }
 
             echo 'Killing container. Container has processed '.$invocationLimit.' invocations. ('.$_ENV['AWS_REQUEST_ID'].')'.PHP_EOL;
 

--- a/src/Runtime/LambdaContainer.php
+++ b/src/Runtime/LambdaContainer.php
@@ -20,7 +20,7 @@ class LambdaContainer
         }
 
         if ($invocations >= $invocationLimit) {
-            if (class_exists(\Laravel\Octane\Contracts\Client::class)) {
+            if (interface_exists(\Laravel\Octane\Contracts\Client::class)) {
                 Octane::terminate();
             }
 

--- a/src/Runtime/LambdaContainer.php
+++ b/src/Runtime/LambdaContainer.php
@@ -20,6 +20,7 @@ class LambdaContainer
         }
 
         if ($invocations >= $invocationLimit) {
+
             if (interface_exists(\Laravel\Octane\Contracts\Client::class)) {
                 Octane::terminate();
             }

--- a/src/Runtime/LambdaContainer.php
+++ b/src/Runtime/LambdaContainer.php
@@ -20,7 +20,6 @@ class LambdaContainer
         }
 
         if ($invocations >= $invocationLimit) {
-
             if (interface_exists(\Laravel\Octane\Contracts\Client::class)) {
                 Octane::terminate();
             }

--- a/src/Runtime/LambdaContainer.php
+++ b/src/Runtime/LambdaContainer.php
@@ -20,7 +20,6 @@ class LambdaContainer
         }
 
         if ($invocations >= $invocationLimit) {
-
             if (class_exists(\Laravel\Octane\Contracts\Client::class)) {
                 Octane::terminate();
             }


### PR DESCRIPTION
This pull request fixes a regression introduced on the latest release that tries to terminate an instance of `Laravel\Octane\Contracts\Client` even if the class don't exist.