### PR TITLE
Octane ELB Query String FIx

### DIFF
--- a/src/Runtime/Octane/OctaneRequestContextFactory.php
+++ b/src/Runtime/Octane/OctaneRequestContextFactory.php
@@ -48,6 +48,10 @@ class OctaneRequestContextFactory
             $method, $contentType, $request->body
         ));
 
+        parse_str($request->serverVariables['QUERY_STRING'], $queryParams);
+
+        $serverRequest = $serverRequest->withQueryParams($queryParams);
+
         return new RequestContext([
             'psr7Request' => $serverRequest,
         ]);

--- a/tests/Feature/LoadBalancedOctaneHandlerTest.php
+++ b/tests/Feature/LoadBalancedOctaneHandlerTest.php
@@ -313,13 +313,38 @@ EOF
 
         $response = $handler->handle([
             'httpMethod' => 'GET',
-            'path' => '/?foo=bar',
+            'path' => '/',
+            'multiValueQueryStringParameters' => [
+                'foo' => ['bar'],
+            ],
             'headers' => [
                 'cookie' => 'XSRF-TOKEN=token_value',
             ],
         ]);
 
         static::assertEquals('foo=bar', $response->toApiGatewayFormat()['body']);
+    }
+
+    public function test_request_query_params()
+    {
+        $handler = new LoadBalancedOctaneHandler();
+
+        Route::get('/', function (Request $request) {
+            return $request->query();
+        });
+
+        $response = $handler->handle([
+            'httpMethod' => 'GET',
+            'path' => '/',
+            'multiValueQueryStringParameters' => [
+                'foo' => ['bar'],
+            ],
+            'headers' => [
+                'cookie' => 'XSRF-TOKEN=token_value',
+            ],
+        ]);
+
+        static::assertEquals(['foo' => 'bar'], json_decode($response->toApiGatewayFormat()['body'], true));
     }
 
     public function test_request_headers()


### PR DESCRIPTION
After enabling Octane in my testing environment (ELB w/ Docker runtime) I found that any routes that contained query string logic were broken. `request()->query()` always returns an empty array.

This PR sets explicitly sets the query params on the PSR7 request instance which seems to resolve the issue. Without this change, the `test_request_query_params` test I added fails.

Additionally, Lambda events from ELB seem to put query string params in the `multiValueQueryStringParameters` field, **not** in `path`.