### PR TITLE
[2.x] Fixes missing server software environment variable

### DIFF
--- a/src/Runtime/Octane/Octane.php
+++ b/src/Runtime/Octane/Octane.php
@@ -66,6 +66,8 @@ class Octane implements Client
      */
     public static function boot($basePath, $databaseSessionPersist = false, $databaseSessionTtl = 0)
     {
+        self::ensureServerSoftware('vapor');
+
         $databaseSessionTtl = (int) $databaseSessionTtl;
 
         static::$worker = tap(new Worker(
@@ -184,6 +186,8 @@ class Octane implements Client
             static::$worker->terminate();
 
             static::$worker = null;
+
+            self::ensureServerSoftware(null);
         }
     }
 
@@ -240,5 +244,17 @@ class Octane implements Client
             fwrite(STDERR, $throwable->getMessage());
             fwrite(STDERR, $e->getMessage());
         }
+    }
+
+    /**
+     * Ensures the given software is set globally.
+     *
+     * @param  string|null  $software
+     * @return void
+     */
+    protected static function ensureServerSoftware($software)
+    {
+        $_ENV['SERVER_SOFTWARE'] = $software;
+        $_SERVER['SERVER_SOFTWARE'] = $software;
     }
 }

--- a/src/Runtime/Octane/Octane.php
+++ b/src/Runtime/Octane/Octane.php
@@ -247,7 +247,7 @@ class Octane implements Client
     }
 
     /**
-     * Ensures the given software is set globally.
+     * Ensures the given software name is set globally.
      *
      * @param  string|null  $software
      * @return void

--- a/tests/Feature/OctaneTest.php
+++ b/tests/Feature/OctaneTest.php
@@ -69,4 +69,10 @@ class OctaneTest extends TestCase
 
         Event::assertDispatched(WorkerErrorOccurred::class);
     }
+
+    public function test_server_software()
+    {
+        self::assertSame('vapor', $_ENV['SERVER_SOFTWARE']);
+        self::assertSame('vapor', $_SERVER['SERVER_SOFTWARE']);
+    }
 }


### PR DESCRIPTION
Some packages, like Livewire, use this environment variable to set a specific cache folder.