### PR TITLE
Refactoring Scheme & Port In Signed Storage URLs

### DIFF
--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -42,7 +42,7 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
             'uuid' => $uuid,
             'bucket' => $bucket,
             'key' => $key,
-            'url' => 'https://'.$uri->getHost().$uri->getPath().'?'.$uri->getQuery(),
+            'url' => $uri->getScheme().'://'.$uri->getAuthority().$uri->getPath().'?'.$uri->getQuery(),
             'headers' => $this->headers($request, $signedRequest),
         ], 201);
     }

--- a/tests/Feature/SignedStorageUrlEndpointTest.php
+++ b/tests/Feature/SignedStorageUrlEndpointTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Laravel\Vapor\Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Vapor\VaporServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class SignedStorageUrlEndpointTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [
+            VaporServiceProvider::class,
+        ];
+    }
+
+    public function test_signed_url_preserves_its_components(): void
+    {
+        Config::set([
+            'filesystems.disks.s3.bucket' => $_ENV['AWS_BUCKET'] = 'storage',
+            'filesystems.disks.s3.key' => $_ENV['AWS_ACCESS_KEY_ID'] = 'sail',
+            'filesystems.disks.s3.region' => $_ENV['AWS_DEFAULT_REGION'] = 'us-east-1',
+            'filesystems.disks.s3.secret' => $_ENV['AWS_SECRET_ACCESS_KEY'] = 'password',
+            'filesystems.disks.s3.url' => $_ENV['AWS_URL'] = 'http://minio:9000',
+            'filesystems.disks.s3.use_path_style_endpoint' => true,
+        ]);
+
+        Gate::define('uploadFiles', static function ($user = null, $bucket = null): bool {
+            return true;
+        });
+
+        $response = $this->json('POST', '/vapor/signed-storage-url')
+            ->assertStatus(201);
+
+        $components = (object) [
+            'actual' => parse_url($response->json('url')),
+            'expected' => parse_url($_ENV['AWS_URL'].'/'.$_ENV['AWS_BUCKET']),
+        ];
+
+        $this->assertEquals($components->expected['scheme'], $components->actual['scheme']);
+        $this->assertEquals($components->expected['host'], $components->actual['host']);
+        $this->assertEquals($components->expected['port'], $components->actual['port']);
+        $this->assertStringStartsWith($components->expected['path'], $components->actual['path']);
+    }
+}


### PR DESCRIPTION
I've found an issue trying to generate a signed storage URL using **MinIO** in a **Sail** stack for its scheme (`http`) and mapped port (`9000`) will diverge from the ones returned by `/vapor/signed-storage-url` currently. This pull request proposes the following changes:

- It replaces the hardcoded `https` scheme with the scheme coming from the previously generated signed URI.
- It replaces the usage of `$uri->getHost()` with `$uri->getAuthority()` so the port coming from the previously generated signed URI can also be included.

I reckon these changes don't affect existing usages of this endpoint.