### PR TITLE
[2.x] Do not use guzzlehttp/promises 1.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "php": "^7.2|^8.0",
         "aws/aws-sdk-php": "^3.80",
         "guzzlehttp/guzzle": "^6.3|^7.0",
+        "guzzlehttp/promises": "<1.5.0",
         "hollodotme/fast-cgi-client": "^3.0",
         "illuminate/container": "^6.0|^7.0|^8.0",
         "illuminate/http": "^6.0|^7.0|^8.0",


### PR DESCRIPTION
This pull request avoids the installation of `guzzlehttp/promises@v1.5.0` that is currently broken when used by the AWS SDK. It unclear the source of the issue at this time, but it causes the same request been "handled" twice by the FPM handler of Vapor.

This a temporary solution, until we ( or the community ) fix the issue next week.