### PR TITLE
[2.x] Fixes redirects to "www" when using subdomains

### DIFF
--- a/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
+++ b/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
@@ -29,6 +29,7 @@ class EnsureOnNakedDomain
 
         if (config('vapor.redirect_to_root') === false) {
             $url = parse_url(config('app.url'));
+
             $nakedHost = preg_replace('#^www\.(.+\.)#i', '$1', $url[
                 'host'
             ]);

--- a/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
+++ b/src/Runtime/Http/Middleware/EnsureOnNakedDomain.php
@@ -27,13 +27,19 @@ class EnsureOnNakedDomain
             ), 301);
         }
 
-        if (config('vapor.redirect_to_root') === false &&
-            strpos($request->getHost(), 'www.') === false) {
-            return new RedirectResponse(str_replace(
-                $request->getScheme().'://',
-                $request->getScheme().'://www.',
-                $request->fullUrl()
-            ), 301);
+        if (config('vapor.redirect_to_root') === false) {
+            $url = parse_url(config('app.url'));
+            $nakedHost = preg_replace('#^www\.(.+\.)#i', '$1', $url[
+                'host'
+            ]);
+
+            if ($request->getHost() === $nakedHost) {
+                return new RedirectResponse(str_replace(
+                    $request->getScheme().'://',
+                    $request->getScheme().'://www.',
+                    $request->fullUrl()
+                ), 301);
+            }
         }
 
         return $next($request);

--- a/tests/Feature/EnsureOnNakedDomainTest.php
+++ b/tests/Feature/EnsureOnNakedDomainTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Laravel\Vapor\Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Laravel\Vapor\Runtime\Http\Middleware\EnsureOnNakedDomain;
+use Laravel\Vapor\VaporServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class EnsureOnNakedDomainTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_ENV['APP_VANITY_URL'] = 'https://something.vapor-farm.com';
+
+        Route::get('/', function () {
+            return 'Hello World';
+        })->middleware(EnsureOnNakedDomain::class);
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            VaporServiceProvider::class,
+        ];
+    }
+
+    /**
+     * @dataProvider useCases
+     */
+    public function test_redirects($useCase)
+    {
+        config()->set('vapor.redirect_to_root', $useCase['redirect_to_root']);
+        config()->set('app.url', $useCase['app_url']);
+
+        $response = $this->get($useCase['request_url']);
+
+        $response->assertStatus($useCase['response_status']);
+
+        if ($useCase['response_status'] == 301) {
+            $response->assertRedirect($useCase['redirected_to']);
+        }
+    }
+
+    public function useCases()
+    {
+        return [
+            [[
+                'app_url' => 'https://domain.com',
+                'request_url' => 'https://domain.com',
+                'redirect_to_root' => true,
+                'response_status' => 200,
+            ]],
+            [[
+                'app_url' => 'https://domain.net.io',
+                'request_url' => 'https://domain.net.io',
+                'redirect_to_root' => true,
+                'response_status' => 200,
+            ]],
+            [[
+                'app_url' => 'https://domain.com',
+                'request_url' => 'https://www.domain.com',
+                'redirect_to_root' => true,
+                'response_status' => 301,
+                'redirected_to' => 'https://domain.com',
+            ]],
+            [[
+                'app_url' => 'https://domain.net.io',
+                'request_url' => 'https://www.domain.net.io',
+                'redirect_to_root' => true,
+                'response_status' => 301,
+                'redirected_to' => 'https://domain.net.io',
+            ]],
+            [[
+                'app_url' => 'https://domain.com',
+                'request_url' => 'https://sub.domain.com',
+                'redirect_to_root' => true,
+                'response_status' => 200,
+            ]],
+            [[
+                'app_url' => 'https://domain.net.io',
+                'request_url' => 'https://sub.domain.net.io',
+                'redirect_to_root' => true,
+                'response_status' => 200,
+            ]],
+
+            // redirect_to_root => false
+            [[
+                'app_url' => 'https://domain.com',
+                'request_url' => 'https://www.domain.com',
+                'redirect_to_root' => false,
+                'response_status' => 200,
+            ]],
+            [[
+                'app_url' => 'https://domain.net.io',
+                'request_url' => 'https://www.domain.net.io',
+                'redirect_to_root' => false,
+                'response_status' => 200,
+            ]],
+            [[
+                'app_url' => 'https://domain.com',
+                'request_url' => 'https://domain.com',
+                'redirect_to_root' => false,
+                'response_status' => 301,
+                'redirected_to' => 'https://www.domain.com',
+            ]],
+            [[
+                'app_url' => 'https://domain.net.io',
+                'request_url' => 'https://domain.net.io',
+                'redirect_to_root' => false,
+                'response_status' => 301,
+                'redirected_to' => 'https://www.domain.net.io',
+            ]],
+            [[
+                'app_url' => 'https://domain.com',
+                'request_url' => 'https://sub.domain.com',
+                'redirect_to_root' => false,
+                'response_status' => 200,
+            ]],
+            [[
+                'app_url' => 'https://domain.net.io',
+                'request_url' => 'https://sub.domain.net.io',
+                'redirect_to_root' => false,
+                'response_status' => 200,
+            ]],
+        ];
+    }
+}


### PR DESCRIPTION
This pull request fixes the usage of wildcard domains combined wit the option `'redirect_to_root' => false`. Meaning that while we were redirecting `domain.com` to `www.domain.com`, the `sub.domain.com` was being redirected to `www.sub.domain.com`. So we fix this issue, by never redirecting subdomains.