### PR TITLE
Check if Content-Type Contains `application/x-www-form-urlencoded`

### DIFF
--- a/src/Runtime/Octane/OctaneRequestContextFactory.php
+++ b/src/Runtime/Octane/OctaneRequestContextFactory.php
@@ -136,8 +136,8 @@ class OctaneRequestContextFactory
     protected static function uploadedFiles($method, $contentType, $body)
     {
         if ($method !== 'POST' ||
-            is_null($contentType = $contentType) ||
-            $contentType === 'application/x-www-form-urlencoded') {
+            is_null($contentType) ||
+            static::isUrlEncodedForm($contentType)) {
             return [];
         }
 
@@ -158,7 +158,7 @@ class OctaneRequestContextFactory
             return;
         }
 
-        if (strtolower($contentType) === 'application/x-www-form-urlencoded') {
+        if (static::isUrlEncodedForm($contentType)) {
             parse_str($body, $parsedBody);
 
             return $parsedBody;
@@ -190,5 +190,16 @@ class OctaneRequestContextFactory
                     ? Arr::setMultiPartArrayValue($parsedBody, $name, $part->getBody())
                     : SupportArr::set($parsedBody, $name, $part->getBody());
             }, []);
+    }
+
+    /**
+     * Check if Content-Type is Url Encoded Form.
+     *
+     * @param  string  $contentType
+     * @return bool
+     */
+    protected static function isUrlEncodedForm($contentType)
+    {
+        return Str::contains(strtolower($contentType), 'application/x-www-form-urlencoded');
     }
 }

--- a/src/Runtime/Octane/OctaneRequestContextFactory.php
+++ b/src/Runtime/Octane/OctaneRequestContextFactory.php
@@ -193,7 +193,7 @@ class OctaneRequestContextFactory
     }
 
     /**
-     * Check if Content-Type is Url Encoded Form.
+     * Determine if the given content type represents a URL encoded form.
      *
      * @param  string  $contentType
      * @return bool


### PR DESCRIPTION
Problem:

Content-Type Header is sent as, `application/x-www-form-urlencoded; charset=UTF-8` and OctaneRequestContextFactory is doing a strict check without taking into account charset etc.

I have a simple jQuery $.post which tends to append the charset.

Solution:

Check if header contains `application/x-www-form-urlencoded`


Not an issue in non Octane vapor world.