### PR TITLE
Adds `vapor.signed_url_expires_after`

### DIFF
--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -31,9 +31,11 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
 
         $uuid = (string) Str::uuid();
 
+        $expiresAfter = config('vapor.signed_url_expires_after', 5);
+
         $signedRequest = $client->createPresignedRequest(
             $this->createCommand($request, $client, $bucket, $key = ('tmp/'.$uuid)),
-            '+5 minutes'
+            sprintf('+%s minutes', $expiresAfter),
         );
 
         $uri = $signedRequest->getUri();

--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -35,7 +35,7 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
 
         $signedRequest = $client->createPresignedRequest(
             $this->createCommand($request, $client, $bucket, $key = ('tmp/'.$uuid)),
-            sprintf('+%s minutes', $expiresAfter),
+            sprintf('+%s minutes', $expiresAfter)
         );
 
         $uri = $signedRequest->getUri();

--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -31,7 +31,7 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
 
         $uuid = (string) Str::uuid();
 
-        $expiresAfter = config('vapor.signed_url_expires_after', 5);
+        $expiresAfter = config('vapor.signed_storage_url_expires_after', 5);
 
         $signedRequest = $client->createPresignedRequest(
             $this->createCommand($request, $client, $bucket, $key = ('tmp/'.$uuid)),

--- a/tests/Feature/SignedStorageUrlEndpointTest.php
+++ b/tests/Feature/SignedStorageUrlEndpointTest.php
@@ -44,4 +44,29 @@ class SignedStorageUrlEndpointTest extends TestCase
         $this->assertEquals($components->expected['port'], $components->actual['port']);
         $this->assertStringStartsWith($components->expected['path'], $components->actual['path']);
     }
+
+    public function test_signed_url_expires_after(): void
+    {
+        Config::set([
+            'filesystems.disks.s3.bucket' => $_ENV['AWS_BUCKET'] = 'storage',
+            'filesystems.disks.s3.key' => $_ENV['AWS_ACCESS_KEY_ID'] = 'sail',
+            'filesystems.disks.s3.region' => $_ENV['AWS_DEFAULT_REGION'] = 'us-east-1',
+            'filesystems.disks.s3.secret' => $_ENV['AWS_SECRET_ACCESS_KEY'] = 'password',
+            'filesystems.disks.s3.url' => $_ENV['AWS_URL'] = 'http://minio:9000',
+            'filesystems.disks.s3.use_path_style_endpoint' => true,
+        ]);
+
+        Gate::define('uploadFiles', static function ($user = null, $bucket = null): bool {
+            return true;
+        });
+
+        $response = $this->json('POST', '/vapor/signed-storage-url');
+        parse_str($response->json()['url'], $queryParams);
+        $this->assertEquals(300, $queryParams['X-Amz-Expires']);
+
+        config()->set('vapor.signed_url_expires_after', 6);
+        $response = $this->json('POST', '/vapor/signed-storage-url');
+        parse_str($response->json()['url'], $queryParams);
+        $this->assertEquals(360, $queryParams['X-Amz-Expires']);
+    }
 }

--- a/tests/Feature/SignedStorageUrlEndpointTest.php
+++ b/tests/Feature/SignedStorageUrlEndpointTest.php
@@ -64,7 +64,7 @@ class SignedStorageUrlEndpointTest extends TestCase
         parse_str($response->json()['url'], $queryParams);
         $this->assertEquals(300, $queryParams['X-Amz-Expires']);
 
-        config()->set('vapor.signed_url_expires_after', 6);
+        config()->set('vapor.signed_storage_url_expires_after', 6);
         $response = $this->json('POST', '/vapor/signed-storage-url');
         parse_str($response->json()['url'], $queryParams);
         $this->assertEquals(360, $queryParams['X-Amz-Expires']);


### PR DESCRIPTION
This pull request allows to customize the signed urls TTL. If eventually, more customers start using this, we will add it the configuration file "stub".