### PR TITLE
[2.x] Fixes `escapeshellarg: argument exceeds the allowed length`

### DIFF
--- a/src/Events/LambdaEvent.php
+++ b/src/Events/LambdaEvent.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Laravel\Vapor\Events;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
+
+class LambdaEvent implements ArrayAccess, Arrayable
+{
+    /**
+     * The underlying event.
+     *
+     * @var array
+     */
+    protected $event;
+
+    /**
+     * Creates a new event instance.
+     *
+     * @param  array  $event
+     * @return void
+     */
+    public function __construct($event)
+    {
+        $this->event = $event;
+    }
+
+    /**
+     * Determine if an item exists at an offset.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetExists($key)
+    {
+        return Arr::exists($this->event, $key);
+    }
+
+    /**
+     * Get an item at a given offset.
+     *
+     * @param  string  $key
+     * @return array|string|int
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetGet($key)
+    {
+        return Arr::get($this->event, $key);
+    }
+
+    /**
+     * Set the item at a given offset.
+     *
+     * @param  string  $key
+     * @param  array|string|int  $value
+     * @return void
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetSet($key, $value)
+    {
+        Arr::set($this->event, $key, $value);
+    }
+
+    /**
+     * Unset the item at a given offset.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($key)
+    {
+        Arr::forget($this->event, $key);
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->event;
+    }
+}

--- a/tests/Fixtures/lambdaEvent.json
+++ b/tests/Fixtures/lambdaEvent.json
@@ -1,0 +1,22 @@
+{
+   "Records":[
+      {
+         "messageId":"58600123-d011-4d76-af5d-960159ca44aa",
+         "receiptHandle":"AQEBberAbZm/iuRDZevRaZ1cd1arwj3mHxvAZo/972KO8UH+HiNMTOMl66TPi/pZUbNYu+owiBzhyVGafAJuGDz9+LoyzEt6JqxMrzOKV7C3IO6wRZsUKRBKrlfr42KKP/+KS8zQUJE3QIgWiAwEfEwTnbSLhsxfqGxTFWzLh5+Or7u8U10p3K8tdDozssv2Hr39RhkiOKbuE2CS1U6f1oUvHowIr6o5vqNy9xxEiYr/XDXqbsReBE5zw531guvXxJagJjjKhxaNJoIozuYotF/+TeAz8/0Y0kuQTHZY0/tgS79MWGIPEL6izkF5uDm2lKo5PP4SKqfNMvNHS/i5u35mqzOQfHhJytLMWoRmCwUShI4KSaVNkkX+4ZyBpflOpLQl6u/DJ5TbfgkzWOJqhV+DQQ==",
+         "body":"{\"uuid\":\"0a0bcc75-f78b-4f15-b834-78e71c56afa3\",\"displayName\":\"Closure (web.php:19)\",\"job\":\"Illuminate\\\\Queue\\\\CallQueuedHandler@call\",\"maxTries\":null,\"maxExceptions\":null,\"failOnTimeout\":false,\"backoff\":null,\"timeout\":null,\"retryUntil\":null,\"data\":{\"commandName\":\"Illuminate\\\\Queue\\\\CallQueuedClosure\",\"command\":\"O:34:\\\"Illuminate\\\\Queue\\\\CallQueuedClosure\\\":14:{s:7:\\\"closure\\\";O:47:\\\"Laravel\\\\SerializableClosure\\\\SerializableClosure\\\":1:{s:12:\\\"serializable\\\";O:46:\\\"Laravel\\\\SerializableClosure\\\\Serializers\\\\Signed\\\":2:{s:12:\\\"serializable\\\";s:432:\\\"O:46:\\\"Laravel\\\\SerializableClosure\\\\Serializers\\\\Native\\\":5:{s:3:\\\"use\\\";a:1:{s:10:\\\"collection\\\";O:29:\\\"Illuminate\\\\Support\\\\Collection\\\":2:{s:8:\\\"\\u0000*\\u0000items\\\";a:1:{i:0;s:4:\\\"nuno\\\";}s:28:\\\"\\u0000*\\u0000escapeWhenCastingToString\\\";b:0;}}s:8:\\\"function\\\";s:79:\\\"function () use ($collection) {\\n \\\\info($collection->implode(','));\\n }\\\";s:5:\\\"scope\\\";s:37:\\\"Illuminate\\\\Routing\\\\RouteFileRegistrar\\\";s:4:\\\"this\\\";N;s:4:\\\"self\\\";s:32:\\\"00000000000001a10000000000000000\\\";}\\\";s:4:\\\"hash\\\";s:44:\\\"bl2j1wIRyXIqlgbMDpY7+kCIUvwcJwhHde9gTY7Ma4E=\\\";}}s:16:\\\"failureCallbacks\\\";a:0:{}s:23:\\\"deleteWhenMissingModels\\\";b:1;s:7:\\\"batchId\\\";N;s:3:\\\"job\\\";N;s:10:\\\"connection\\\";N;s:5:\\\"queue\\\";N;s:15:\\\"chainConnection\\\";N;s:10:\\\"chainQueue\\\";N;s:19:\\\"chainCatchCallbacks\\\";N;s:5:\\\"delay\\\";N;s:11:\\\"afterCommit\\\";N;s:10:\\\"middleware\\\";a:0:{}s:7:\\\"chained\\\";a:0:{}}\"},\"attempts\":0}",
+         "attributes":{
+            "ApproximateReceiveCount":"1",
+            "SentTimestamp":"1639158884706",
+            "SenderId":"AROATHDQZYADPZZTHGFLF:vapor-laravel-staging",
+            "ApproximateFirstReceiveTimestamp":"1639158884710"
+         },
+         "messageAttributes":[
+
+         ],
+         "md5OfBody":"28381da423cdb6fb5ba21f2eccb4fea1",
+         "eventSource":"aws:sqs",
+         "eventSourceARN":"arn:aws:sqs:eu-west-3:221427384326:laravel-staging",
+         "awsRegion":"eu-west-3"
+      }
+   ]
+}

--- a/tests/Unit/LambdaEventTest.php
+++ b/tests/Unit/LambdaEventTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Laravel\Vapor\Tests\Unit;
+
+use Laravel\Vapor\Events\LambdaEvent;
+use PHPUnit\Framework\TestCase;
+
+class LambdaEventTest extends TestCase
+{
+    public function test_to_array()
+    {
+        $event = $this->getEvent();
+
+        $this->assertIsArray($event->toArray());
+    }
+
+    public function test_array_access()
+    {
+        $event = $this->getEvent();
+
+        $this->assertIsArray($event['Records']);
+
+        $this->assertSame('58600123-d011-4d76-af5d-960159ca44aa', $event['Records.0.messageId']);
+        $this->assertSame('1', $event['Records.0.attributes.ApproximateReceiveCount']);
+
+        unset($event['Records']);
+        $this->assertFalse(isset($event['Records']));
+
+        $event['Records'] = [['messageId' => 'foo']];
+        $this->assertTrue(isset($event['Records']));
+        $this->assertSame('foo', $event['Records.0.messageId']);
+    }
+
+    public function getEvent()
+    {
+        return new LambdaEvent(json_decode(
+            file_get_contents(__DIR__.'/../Fixtures/LambdaEvent.json'),
+            true
+        ));
+    }
+}

--- a/tests/Unit/LambdaEventTest.php
+++ b/tests/Unit/LambdaEventTest.php
@@ -34,7 +34,7 @@ class LambdaEventTest extends TestCase
     public function getEvent()
     {
         return new LambdaEvent(json_decode(
-            file_get_contents(__DIR__.'/../Fixtures/LambdaEvent.json'),
+            file_get_contents(__DIR__.'/../Fixtures/lambdaEvent.json'),
             true
         ));
     }

--- a/tests/Unit/QueueHandlerTest.php
+++ b/tests/Unit/QueueHandlerTest.php
@@ -3,8 +3,8 @@
 namespace Laravel\Vapor\Tests\Unit;
 
 use Laravel\Vapor\Events\LambdaEvent;
-use Mockery;
 use Laravel\Vapor\Runtime\Handlers\QueueHandler;
+use Mockery;
 use Orchestra\Testbench\TestCase;
 
 class QueueHandlerTest extends TestCase

--- a/tests/Unit/QueueHandlerTest.php
+++ b/tests/Unit/QueueHandlerTest.php
@@ -4,9 +4,10 @@ namespace Laravel\Vapor\Tests\Unit;
 
 use Laravel\Vapor\Events\LambdaEvent;
 use Mockery;
+use Laravel\Vapor\Runtime\Handlers\QueueHandler;
 use Orchestra\Testbench\TestCase;
 
-class VaporWorkCommandTest extends TestCase
+class QueueHandlerTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -20,7 +21,7 @@ class VaporWorkCommandTest extends TestCase
         Mockery::close();
     }
 
-    public function test_command_can_be_called()
+    public function test_job_can_be_called()
     {
         $this->assertFalse(FakeJob::$handled);
 
@@ -28,7 +29,7 @@ class VaporWorkCommandTest extends TestCase
 
         $event = $this->getEvent();
 
-        $event['Records.0.body'] = json_encode([
+        $event['Records'][0]['body'] = json_encode([
             'displayName' => FakeJob::class,
             'job' => 'Illuminate\Queue\CallQueuedHandler@call',
             'maxTries' => null,
@@ -41,10 +42,13 @@ class VaporWorkCommandTest extends TestCase
             'attempts' => 0,
         ]);
 
-        $this->instance(LambdaEvent::class, $event);
+        QueueHandler::$app = $this->app;
 
-        $this->artisan('vapor:work');
+        $queueHandler = new QueueHandler();
 
+        $this->assertFalse(QueueHandler::$app->bound(LambdaEvent::class));
+        $queueHandler->handle($event);
+        $this->assertFalse(QueueHandler::$app->bound(LambdaEvent::class));
         $this->assertTrue(FakeJob::$handled);
     }
 
@@ -72,9 +76,9 @@ class VaporWorkCommandTest extends TestCase
 
     protected function getEvent()
     {
-        return new LambdaEvent(json_decode(
+        return json_decode(
             file_get_contents(__DIR__.'/../Fixtures/lambdaEvent.json'),
             true
-        ));
+        );
     }
 }

--- a/tests/Unit/VaporWorkCommandTest.php
+++ b/tests/Unit/VaporWorkCommandTest.php
@@ -84,7 +84,7 @@ class VaporWorkCommandTest extends TestCase
     public function getEvent()
     {
         return new LambdaEvent(json_decode(
-            file_get_contents(__DIR__.'/../Fixtures/LambdaEvent.json'),
+            file_get_contents(__DIR__.'/../Fixtures/lambdaEvent.json'),
             true
         ));
     }


### PR DESCRIPTION
This pull request addresses the error `escapeshellarg: argument exceeds the allowed length` that could cause the `VaporWorkCommand` to process the same message hundreds of times. 

The issue relies on having us serialize the entire job payload to a Symfony String Input, and then, once Symfony console tries to deserialize that job payload (specially on big job payloads), the error `escapeshellarg: argument exceeds the allowed length` appears - because of OS limitations - causing the job to be re-queued to SQS, and retried over and over again.

Now, the fix is simple, we no longer serialize the job payload to the Symfony String Input, and we bind the event to the container. After that, once the container resolves the command@handle, it will resolve the event, and infer the job content from that.

Of course, once we finish the process of the job, we unbind the event from the container.