### PR TITLE
[2.x] Adds support for `octane:status` 

### DIFF
--- a/src/Console/Commands/OctaneStatusCommand.php
+++ b/src/Console/Commands/OctaneStatusCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Vapor\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class OctaneStatusCommand extends Command
+{
+    /**
+     * The command's signature.
+     *
+     * @var string
+     */
+    public $signature = 'octane:status';
+
+    /**
+     * The command's description.
+     *
+     * @var string
+     */
+    public $description = 'Get the current status of the Octane server';
+
+    /**
+     * Handle the command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $this->isEnviromentRunningOnOctane()
+            ? $this->info('Octane server is running.')
+            : $this->info('Octane server is not running.');
+    }
+
+    /**
+     * Check if the enviroment is running on Octane.
+     *
+     * @return bool
+     */
+    protected function isEnviromentRunningOnOctane()
+    {
+        return isset($_ENV['OCTANE_DATABASE_SESSION_TTL']);
+    }
+}

--- a/src/Console/Commands/OctaneStatusCommand.php
+++ b/src/Console/Commands/OctaneStatusCommand.php
@@ -33,7 +33,7 @@ class OctaneStatusCommand extends Command
     }
 
     /**
-     * Check if the enviroment is running on Octane.
+     * Determine if the enviroment is running on Octane.
      *
      * @return bool
      */

--- a/src/VaporServiceProvider.php
+++ b/src/VaporServiceProvider.php
@@ -27,7 +27,7 @@ class VaporServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->ensureRoutesAreDefined();
-        $this->overrideOctaneStatusCommand();
+        $this->registerOctaneCommands();
 
         if (($_ENV['VAPOR_SERVERLESS_DB'] ?? null) === 'true') {
             Schema::defaultStringLength(191);
@@ -166,8 +166,20 @@ class VaporServiceProvider extends ServiceProvider
         $this->commands(['command.vapor.work']);
     }
 
-    protected function overrideOctaneStatusCommand()
+    /**
+     * Register the Vapor "Octane" console commands.
+     *
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function registerOctaneCommands()
     {
+        // Ensure we are running on Vapor...
+        if (! isset($_ENV['VAPOR_SSM_PATH'])) {
+            return;
+        }
+
         if ($this->app->runningInConsole()) {
             $this->commands(OctaneStatusCommand::class);
         }

--- a/src/VaporServiceProvider.php
+++ b/src/VaporServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
+use Laravel\Vapor\Console\Commands\OctaneStatusCommand;
 use Laravel\Vapor\Console\Commands\VaporWorkCommand;
 use Laravel\Vapor\Http\Controllers\SignedStorageUrlController;
 use Laravel\Vapor\Http\Middleware\ServeStaticAssets;
@@ -26,6 +27,7 @@ class VaporServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->ensureRoutesAreDefined();
+        $this->overrideOctaneStatusCommand();
 
         if (($_ENV['VAPOR_SERVERLESS_DB'] ?? null) === 'true') {
             Schema::defaultStringLength(191);
@@ -162,5 +164,12 @@ class VaporServiceProvider extends ServiceProvider
         });
 
         $this->commands(['command.vapor.work']);
+    }
+
+    protected function overrideOctaneStatusCommand()
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands(OctaneStatusCommand::class);
+        }
     }
 }

--- a/tests/Feature/Commands/OctaneStatusCommandTest.php
+++ b/tests/Feature/Commands/OctaneStatusCommandTest.php
@@ -6,6 +6,13 @@ use Laravel\Vapor\Tests\TestCase;
 
 class OctaneStatusCommandTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        $_ENV['VAPOR_SSM_PATH'] = 'foo';
+
+        parent::setUp();
+    }
+
     public function test_when_octane_is_not_running()
     {
         $this->artisan('octane:status')
@@ -25,6 +32,7 @@ class OctaneStatusCommandTest extends TestCase
     protected function tearDown(): void
     {
         unset($_ENV['OCTANE_DATABASE_SESSION_TTL']);
+        unset($_ENV['VAPOR_SSM_PATH']);
 
         parent::tearDown();
     }

--- a/tests/Feature/Commands/OctaneStatusCommandTest.php
+++ b/tests/Feature/Commands/OctaneStatusCommandTest.php
@@ -2,6 +2,10 @@
 
 namespace Laravel\Vapor\Tests\Feature\Commands;
 
+if (! interface_exists(\Laravel\Octane\Contracts\Client::class)) {
+    return;
+}
+
 use Laravel\Vapor\Tests\TestCase;
 
 class OctaneStatusCommandTest extends TestCase

--- a/tests/Feature/Commands/OctaneStatusCommandTest.php
+++ b/tests/Feature/Commands/OctaneStatusCommandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Laravel\Vapor\Tests\Feature\Commands;
+
+use Laravel\Vapor\Tests\TestCase;
+
+class OctaneStatusCommandTest extends TestCase
+{
+    public function test_when_octane_is_not_running()
+    {
+        $this->artisan('octane:status')
+            ->assertSuccessful()
+            ->expectsOutput('Octane server is not running.');
+    }
+
+    public function test_when_octane_is_running()
+    {
+        $_ENV['OCTANE_DATABASE_SESSION_TTL'] = 'false';
+
+        $this->artisan('octane:status')
+            ->assertSuccessful()
+            ->expectsOutput('Octane server is running.');
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_ENV['OCTANE_DATABASE_SESSION_TTL']);
+
+        parent::tearDown();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Laravel\Vapor\Tests;
 
 use Laravel\Octane\OctaneServiceProvider;
+use Laravel\Vapor\VaporServiceProvider;
 use Mockery;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
@@ -17,6 +18,9 @@ abstract class TestCase extends BaseTestCase
 
     protected function getPackageProviders($app)
     {
-        return [OctaneServiceProvider::class];
+        return [
+            OctaneServiceProvider::class,
+            VaporServiceProvider::class,
+        ];
     }
 }


### PR DESCRIPTION
This pull request adds support for the `octane:status` artisan command.

Previously, this command was returning "Octane not running" as Vapor don't use Swoole or Roadrunner. Now, by checking the `OCTANE_DATABASE_SESSION_TTL`, we are able to see if the environment has Octane enabled or not.

Note that the command is registered at `boot` level, so we can override Octane commands.