### PR TITLE
[2.x] Avoids runtime exception on invalid URI

### DIFF
--- a/src/Runtime/Octane/OctaneRequestContextFactory.php
+++ b/src/Runtime/Octane/OctaneRequestContextFactory.php
@@ -31,7 +31,7 @@ class OctaneRequestContextFactory
 
         $serverRequest = new ServerRequest(
             $request->serverVariables['REQUEST_METHOD'],
-            $request->serverVariables['REQUEST_URI'],
+            static::parseUri($request->serverVariables['REQUEST_URI']),
             $request->headers,
             $request->body,
             $request->serverVariables['SERVER_PROTOCOL'],
@@ -190,6 +190,21 @@ class OctaneRequestContextFactory
                     ? Arr::setMultiPartArrayValue($parsedBody, $name, $part->getBody())
                     : SupportArr::set($parsedBody, $name, $part->getBody());
             }, []);
+    }
+
+    /**
+     * Parse the incoming event's request uri.
+     *
+     * @param  string  $uri
+     * @return string
+     */
+    protected static function parseUri($uri)
+    {
+        if (parse_url($uri) === false) {
+            return '/';
+        }
+
+        return $uri;
     }
 
     /**

--- a/tests/Feature/LoadBalancedOctaneHandlerTest.php
+++ b/tests/Feature/LoadBalancedOctaneHandlerTest.php
@@ -64,6 +64,22 @@ class LoadBalancedOctaneHandlerTest extends TestCase
         static::assertEquals('Hello World', $response->toApiGatewayFormat()['body']);
     }
 
+    public function test_invalid_uri()
+    {
+        $handler = new LoadBalancedOctaneHandler();
+
+        Route::get('/', function () {
+            return 'Hello World';
+        });
+
+        $response = $handler->handle([
+            'httpMethod' => 'GET',
+            'path' => '/////foo',
+        ]);
+
+        static::assertEquals('Hello World', $response->toApiGatewayFormat()['body']);
+    }
+
     public function test_response_fires_events()
     {
         Event::fake([RequestReceived::class, RequestTerminated::class]);

--- a/tests/Feature/OctaneHandlerTest.php
+++ b/tests/Feature/OctaneHandlerTest.php
@@ -64,6 +64,22 @@ class OctaneHandlerTest extends TestCase
         static::assertEquals('Hello World', $response->toApiGatewayFormat()['body']);
     }
 
+    public function test_invalid_uri()
+    {
+        $handler = new OctaneHandler();
+
+        Route::get('/', function () {
+            return 'Hello World';
+        });
+
+        $response = $handler->handle([
+            'httpMethod' => 'GET',
+            'path' => '/////foo',
+        ]);
+
+        static::assertEquals('Hello World', $response->toApiGatewayFormat()['body']);
+    }
+
     public function test_response_file()
     {
         $handler = new OctaneHandler();


### PR DESCRIPTION
This pull request addresses an issue when a invalid URI is provided to API Gateway such as `https://www.example.com/////` - as this example was throwing the following error:

```
Fatal error: Uncaught InvalidArgumentException: Unable to parse URI: "/////" in /var/task/vendor/nyholm/psr7/src/Uri.php:53 
``` 

Right now, I've opted by a very minimal fix that just redirects to the `/` page, as simulating a true `400 response` would probably involve creating a Vapor Core route on the service provider that returns an `400 response` from the underlying application.