### PR TITLE
Ensure logs path exists for scheduled commands stdout/stderr

### DIFF
--- a/src/Runtime/StorageDirectories.php
+++ b/src/Runtime/StorageDirectories.php
@@ -20,6 +20,7 @@ class StorageDirectories
     {
         $directories = [
             self::PATH.'/app',
+            self::PATH.'/logs',
             self::PATH.'/bootstrap/cache',
             self::PATH.'/framework/cache',
             self::PATH.'/framework/views',


### PR DESCRIPTION
Hello,

When working on trying to capture output from scheduled tasks using the methodology of (using the inspire command as an example) :

```php

$schedule->command('inspire')
    ->thenWithOutput(function($output) {
       
        // send email of output 
        // or 
        // store output to database / log file
        
    });

```

in the kernel file, we found that output was always empty.  Furthermore, the command would actually not run, even though the scheduler said it was running the command, which was true, just that the sub-process never ran.  

Trying to debug and figure this out within a container on lambda running the vapor runtime I dug down into the Event and Scheduler code in the framework what I was finding is that when the function to try to get the output of a scheduled command, the command that was built also included a file / location to store the output to in order for the scheduler to then get that output in the calling process.

This got me to the `runCommandInForeground` function within the event class.  The exit code returning from this result was always a non-zero code and so to try to find out more about why I updated this function and pushed it to a lambda container to see what it was returning from the process that the scheduler itself was trying to run.  

This is essentially what I updated it to do

```php

protected function runCommandInForeground(Container $container)
    {
        try {
            $this->callBeforeCallbacks($container);

            $process = Process::fromShellCommandline(
                $this->buildCommand(), base_path(), null, null, null
            );

            $this->exitCode = $process->run();

            $stdOut = $process->getOutput();
            $stdErr = $process->getErrorOutput();

            // log exit code, stdOut, stdErr  to a database table/row

            $this->callAfterCallbacks($container);
        } finally {
            $this->removeMutex();
        }
    }
```


This is what was logged:
```
ExitCode: 2 STDOUT:  STDERR: sh: 1: cannot create /tmp/storage/logs/schedule-774b9f825abd7c3a58807a2e00a57b29b8751a8c.log: Directory nonexistent
```

From there I tried to find out where / why this directory wsn't there, and just turns out that it's just not created through the StorageDirectories file updated in this PR.  I know the docs here: https://docs.vapor.build/1.0/projects/environments.html#scheduler mention that getting the output in cloudwatch or the vapor ui isn't possible, and maybe this was intentionally left out then from that.  I guess it just would seem odd that we can't use the scheduler's built in output handling functions to store/email that output even though yes, the output is not sent to the cloudwatch logs themselves.

Once adding the directory to ensure that it exists, the original code example does get the output and is able to email/store correctly.  


On a different note, while all I did here was just add to the directories array, I could see this being a configuration item in the vapor config file instead.  So that, if this was intentional, it's at least add-able if desired, as well as for other packages that may use specific folders within the storage folder locally.  One of the other cases we ran into this when migrating into vapor was using the Laravel Excel package.  It allows for storing the main file remotely, but because the underlying phpspreadsheet library requires the file to be local so they put both remote path and local paths in the config: 

https://github.com/SpartnerNL/Laravel-Excel/blob/3.1/config/excel.php#L295

The default option here fails with vapor as well because it can't touch or create the directory path.

Anyway, apologies this is a little long, but somewhat complex to explain, and if using the vapor config to ensure different directories exist would be better, I can update that too.

