### PR TITLE
Add Custom key to s3 signed storage

### DIFF
--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -43,9 +43,9 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
         $uri = $signedRequest->getUri();
 
         $response = [
-            'bucket'  => $bucket,
-            'key'     => $key,
-            'url'     => $uri->getScheme().'://'.$uri->getAuthority().$uri->getPath().'?'.$uri->getQuery(),
+            'bucket' => $bucket,
+            'key' => $key,
+            'url' => $uri->getScheme().'://'.$uri->getAuthority().$uri->getPath().'?'.$uri->getQuery(),
             'headers' => $this->headers($request, $signedRequest),
         ];
 

--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -31,22 +31,29 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
 
         $uuid = (string) Str::uuid();
 
+        $key = $request->input('key') ?: 'tmp/' . $uuid;
+
         $expiresAfter = config('vapor.signed_storage_url_expires_after', 5);
 
         $signedRequest = $client->createPresignedRequest(
-            $this->createCommand($request, $client, $bucket, $key = ('tmp/'.$uuid)),
+            $this->createCommand($request, $client, $bucket, $key),
             sprintf('+%s minutes', $expiresAfter)
         );
 
         $uri = $signedRequest->getUri();
 
-        return response()->json([
-            'uuid' => $uuid,
-            'bucket' => $bucket,
-            'key' => $key,
-            'url' => $uri->getScheme().'://'.$uri->getAuthority().$uri->getPath().'?'.$uri->getQuery(),
+        $response = [
+            'bucket'  => $bucket,
+            'key'     => $key,
+            'url'     => $uri->getScheme() . '://' . $uri->getAuthority() . $uri->getPath() . '?' . $uri->getQuery(),
             'headers' => $this->headers($request, $signedRequest),
-        ], 201);
+        ];
+
+        if (!$request->has('key')) {
+            $response['uuid'] = $uuid;
+        }
+
+        return response()->json($response, 201);
     }
 
     /**

--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -31,7 +31,7 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
 
         $uuid = (string) Str::uuid();
 
-        $key = $request->input('key') ?: 'tmp/' . $uuid;
+        $key = $request->input('key') ?: 'tmp/'.$uuid;
 
         $expiresAfter = config('vapor.signed_storage_url_expires_after', 5);
 
@@ -45,11 +45,11 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
         $response = [
             'bucket'  => $bucket,
             'key'     => $key,
-            'url'     => $uri->getScheme() . '://' . $uri->getAuthority() . $uri->getPath() . '?' . $uri->getQuery(),
+            'url'     => $uri->getScheme().'://'.$uri->getAuthority().$uri->getPath().'?'.$uri->getQuery(),
             'headers' => $this->headers($request, $signedRequest),
         ];
 
-        if (!$request->has('key')) {
+        if (! $request->has('key')) {
             $response['uuid'] = $uuid;
         }
 


### PR DESCRIPTION
Hello,

Most of the time, it is common for us to upload directly to the tmp file, for there are cases that are not necessary because they are files without pre-visualization that require a lot of time due to the size of the file.

I have followed the documentation to upload files via vapor-js and subsequently, tried copied the file using the`Storage::copy` method (via PHP). This resulted in an error on the lambda side due to the tmp folder 512mb restriction.

![photo5179182401346185607](https://user-images.githubusercontent.com/33601626/152331376-94d2529e-473c-4358-917c-3d164e8c6484.jpg)

I have tried, with no success, all the following approaches to upload a large file  (>1GB):

- Upload via [vapor-js](https://github.com/laravel/vapor-js) and copy using Storage::copy
- Upload via vapor-js and copy using multiPartUpload API (with and without background queue processing)
- Make use of s3 javascript package.

Using vapor-js upload is really helpful for lambda server performance. However, I could not make any progress with the folder size restriction, and I was also not able to configure the upload to target another directory.

The situation led me into bringing the **SignedStorageUrlController** into my application and, therefore, adding a custom key to be able to send the file (already validated) into a specified folder. This method avoided having to perform copy.

My implementation does not suggest any changes to the current behavior, but  it adds the possibility to modify the key send via Vapor.store.

In summary:

Upload of vapor-js: tmp/{uuid}. -> I must create another logic to transfer.

With this solution, there is no copy hence it goes directly to the  folder specified in the key.

```javascript
Vapor.store(this.$refs.file.files[0], {
   data: { key: key }
}).then(response => {
// ...
```

videos/{uuid}

so/{uuid}

This key will only be used if necessary, in cases like the one I have encountered.

Thank you