### PR TITLE
Allows to disable redirect to `favicon.ico` logic

### DIFF
--- a/src/Runtime/Http/Middleware/RedirectStaticAssets.php
+++ b/src/Runtime/Http/Middleware/RedirectStaticAssets.php
@@ -15,7 +15,7 @@ class RedirectStaticAssets
      */
     public function handle($request, $next)
     {
-        if (config('vapor.redirect_favicon_ico', true) && $request->path() === 'favicon.ico') {
+        if (config('vapor.redirect_favicon', true) && $request->path() === 'favicon.ico') {
             return new RedirectResponse($_ENV['ASSET_URL'].'/favicon.ico', 302, [
                 'Cache-Control' => 'public, max-age=3600',
             ]);

--- a/src/Runtime/Http/Middleware/RedirectStaticAssets.php
+++ b/src/Runtime/Http/Middleware/RedirectStaticAssets.php
@@ -15,7 +15,7 @@ class RedirectStaticAssets
      */
     public function handle($request, $next)
     {
-        if ($request->path() === 'favicon.ico') {
+        if (config('vapor.redirect_favicon_ico', true) && $request->path() === 'favicon.ico') {
             return new RedirectResponse($_ENV['ASSET_URL'].'/favicon.ico', 302, [
                 'Cache-Control' => 'public, max-age=3600',
             ]);

--- a/tests/Feature/RedirectStaticAssetsTest.php
+++ b/tests/Feature/RedirectStaticAssetsTest.php
@@ -32,7 +32,7 @@ class RedirectStaticAssetsTest extends TestCase
         $response = $this->get('/favicon.ico');
         $response->assertStatus(302)->assertRedirect('https://asset-url.com/favicon.ico');
 
-        config()->set('vapor.redirect_favicon_ico', false);
+        config()->set('vapor.redirect_favicon', false);
 
         $response = $this->get('/favicon.ico');
         $response->assertStatus(200)->assertSee('My own favicon.');

--- a/tests/Feature/RedirectStaticAssetsTest.php
+++ b/tests/Feature/RedirectStaticAssetsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Laravel\Vapor\Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Laravel\Vapor\Runtime\Http\Middleware\RedirectStaticAssets;
+use Laravel\Vapor\VaporServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class RedirectStaticAssetsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_ENV['ASSET_URL'] = 'https://asset-url.com';
+
+        Route::get('/favicon.ico', function () {
+            return 'My own favicon.';
+        })->middleware(RedirectStaticAssets::class);
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            VaporServiceProvider::class,
+        ];
+    }
+
+    public function test_redirects_to_favicon_ico()
+    {
+        $response = $this->get('/favicon.ico');
+        $response->assertStatus(302)->assertRedirect('https://asset-url.com/favicon.ico');
+
+        config()->set('vapor.redirect_favicon_ico', false);
+
+        $response = $this->get('/favicon.ico');
+        $response->assertStatus(200)->assertSee('My own favicon.');
+    }
+}


### PR DESCRIPTION
This pull request allows to disable the redirect to `favicon.ico` logic, so customers can serve an `svg` or any other asset from it.