### PR TITLE
Use new instead of factory() to instantiate the client, since factory() is deprecated

### DIFF
--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -145,7 +145,7 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
             }
         }
 
-        return S3Client::factory($config);
+        return new S3Client($config);
     }
 
     /**


### PR DESCRIPTION
See https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/getting-started_migration.html#comparing-code-samples-from-both-versions-of-the-sdk

V2:
![image](https://user-images.githubusercontent.com/1304003/156154731-9f7c11e3-6296-4d50-adca-f22480d9aca6.png)

V3:
![image](https://user-images.githubusercontent.com/1304003/156154758-a943e084-b2be-4e17-8324-b8d8fe283149.png)