### PR TITLE
make defining routes configurable

### DIFF
--- a/src/DefinesRoutes.php
+++ b/src/DefinesRoutes.php
@@ -17,7 +17,7 @@ trait DefinesRoutes
             return;
         }
 
-        if (config('vapor.define_routes', true)) {
+        if (config('vapor.signed_storage.enabled', true)) {
             Route::post(
                 '/vapor/signed-storage-url',
                 Contracts\SignedStorageUrlController::class.'@store'

--- a/src/DefinesRoutes.php
+++ b/src/DefinesRoutes.php
@@ -19,7 +19,7 @@ trait DefinesRoutes
 
         if (config('vapor.signed_storage.enabled', true)) {
             Route::post(
-                '/vapor/signed-storage-url',
+                config('vapor.signed_storage.url', '/vapor/signed-storage-url'),
                 Contracts\SignedStorageUrlController::class.'@store'
             )->middleware(config('vapor.middleware', 'web'));
         }

--- a/src/DefinesRoutes.php
+++ b/src/DefinesRoutes.php
@@ -17,9 +17,11 @@ trait DefinesRoutes
             return;
         }
 
-        Route::post(
-            '/vapor/signed-storage-url',
-            Contracts\SignedStorageUrlController::class.'@store'
-        )->middleware(config('vapor.middleware', 'web'));
+        if (config('vapor.define_routes', true)) {
+            Route::post(
+                '/vapor/signed-storage-url',
+                Contracts\SignedStorageUrlController::class.'@store'
+            )->middleware(config('vapor.middleware', 'web'));
+        }
     }
 }


### PR DESCRIPTION
Adds config for controlling if vapor should define its routes or not.

Default behaviour is unchanged, meaning it's gonna keep defining routes unless you deliberately make `vapor.define_routes` config `false`.