### PR TITLE
[2.x] Adds `REQUEST_TIME_FLOAT` to server environment variables

### DIFF
--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -67,6 +67,8 @@ class Request
             'REMOTE_PORT' => $headers['x-forwarded-port'] ?? 80,
             'REQUEST_METHOD' => $event['httpMethod'],
             'REQUEST_URI' => $uri,
+            'REQUEST_TIME' => time(),
+            'REQUEST_TIME_FLOAT' => microtime(true),
             'SERVER_ADDR' => '127.0.0.1',
             'SERVER_NAME' => $headers['host'] ?? 'localhost',
             'SERVER_PORT' => $headers['x-forwarded-port'] ?? 80,


### PR DESCRIPTION
This pull request adds the missing `REQUEST_TIME_FLOAT` server environment variable that gets used by Telescope to log the duration of requests. Without Octane, the `LARAVEL_START` constant gets used, yet, with Octane, we need this environment variable set.