### PR TITLE
Fix when cookie has empty value

### DIFF
--- a/src/Runtime/Octane/OctaneRequestContextFactory.php
+++ b/src/Runtime/Octane/OctaneRequestContextFactory.php
@@ -67,7 +67,7 @@ class OctaneRequestContextFactory
     {
         $headers = array_change_key_case($headers);
 
-        if (! isset($headers['cookie'])) {
+        if (! isset($headers['cookie']) || empty($headers['cookie'])) {
             return [];
         }
 


### PR DESCRIPTION
Sometimes the requests might be sent with an empty cookie, causing an error:

`Fatal error: Uncaught ErrorException: Undefined array key 1 in /var/task/vendor/laravel/vapor-core/src/Runtime/Octane/OctaneRequestContextFactory.php:75`