### PR TITLE
Support payload format v2.0

### DIFF
--- a/src/Runtime/Fpm/FpmHttpHandlerFactory.php
+++ b/src/Runtime/Fpm/FpmHttpHandlerFactory.php
@@ -24,7 +24,7 @@ class FpmHttpHandlerFactory
             return new WarmerPingHandler;
         } elseif (isset($event['requestContext']['elb'])) {
             return new LoadBalancedFpmHandler;
-        } elseif (isset($event['httpMethod'])) {
+        } elseif (isset($event['httpMethod']) || isset($event['requestContext']['http']['method'])) {
             return new FpmHandler;
         }
 

--- a/src/Runtime/Octane/OctaneHttpHandlerFactory.php
+++ b/src/Runtime/Octane/OctaneHttpHandlerFactory.php
@@ -24,7 +24,7 @@ class OctaneHttpHandlerFactory
             return new WarmerPingHandler;
         } elseif (isset($event['requestContext']['elb'])) {
             return new LoadBalancedOctaneHandler;
-        } elseif (isset($event['httpMethod'])) {
+        } elseif (isset($event['httpMethod']) || isset($event['requestContext']['http']['method'])) {
             return new OctaneHandler;
         }
 

--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -174,13 +174,6 @@ class Request
      */
     protected static function getHeaders(array $event)
     {
-        if (isset($event['version']) && $event['version'] === '2.0') {
-            return collect($event['headers'] ?? [])
-                ->mapWithKeys(function ($headers, $name) {
-                    return [$name => Arr::last(explode(',', $headers))];
-                })->all();
-        }
-
         if (! isset($event['multiValueHeaders'])) {
             return array_change_key_case(
                 $event['headers'] ?? [], CASE_LOWER

--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -61,18 +61,18 @@ class Request
 
         $serverVariables = array_merge($serverVariables, [
             'GATEWAY_INTERFACE' => 'FastCGI/1.0',
-            'PATH_INFO' => $event['path'] ?? '/',
+            'PATH_INFO' => $event['path'] ??  $event['requestContext']['http']['path'] ?? '/',
             'QUERY_STRING' => $queryString,
             'REMOTE_ADDR' => '127.0.0.1',
             'REMOTE_PORT' => $headers['x-forwarded-port'] ?? 80,
-            'REQUEST_METHOD' => $event['httpMethod'],
+            'REQUEST_METHOD' => $event['httpMethod'] ?? $event['requestContext']['http']['method'],
             'REQUEST_URI' => $uri,
             'REQUEST_TIME' => time(),
             'REQUEST_TIME_FLOAT' => microtime(true),
             'SERVER_ADDR' => '127.0.0.1',
             'SERVER_NAME' => $headers['host'] ?? 'localhost',
             'SERVER_PORT' => $headers['x-forwarded-port'] ?? 80,
-            'SERVER_PROTOCOL' => $event['requestContext']['protocol'] ?? 'HTTP/1.1',
+            'SERVER_PROTOCOL' =>  $event['requestContext']['protocol'] ?? $event['requestContext']['http']['protocol'] ??'HTTP/1.1',
             'SERVER_SOFTWARE' => 'vapor',
         ]);
 
@@ -107,7 +107,7 @@ class Request
      */
     protected static function getUriAndQueryString(array $event)
     {
-        $uri = $event['path'] ?? '/';
+        $uri = $event['requestContext']['http']['path'] ?? $event['path'] ?? '/';
 
         $queryString = self::getQueryString($event);
 
@@ -127,6 +127,15 @@ class Request
      */
     protected static function getQueryString(array $event)
     {
+        if (isset($event['version']) && $event['version'] === '2.0') {
+            return http_build_query(
+                collect($event['queryStringParameters'] ?? [])
+                ->mapWithKeys(function ($value, $key) {
+                    return [$key => explode(',', $value)];
+                })->all()
+            );
+        }
+
         if (! isset($event['multiValueQueryStringParameters'])) {
             return http_build_query(
                 $event['queryStringParameters'] ?? []
@@ -161,6 +170,13 @@ class Request
      */
     protected static function getHeaders(array $event)
     {
+        if (isset($event['version']) && $event['version'] === '2.0') {
+            return collect($event['headers'] ?? [])
+                ->mapWithKeys(function ($headers, $name) {
+                    return [$name => Arr::last(explode(',', $headers))];
+                })->all();
+        }
+
         if (! isset($event['multiValueHeaders'])) {
             return array_change_key_case(
                 $event['headers'] ?? [], CASE_LOWER
@@ -200,7 +216,8 @@ class Request
      */
     protected static function ensureContentTypeIsSet(array $event, array $headers, array $serverVariables)
     {
-        if ((strtoupper($event['httpMethod']) === 'POST') && ! isset($headers['content-type'])) {
+        if ((! isset($headers['content-type']) && isset($event['httpMethod']) && (strtoupper($event['httpMethod']) === 'POST')) ||
+            (! isset($headers['content-type']) && isset($event['requestContext']['http']['method']) && (strtoupper($event['requestContext']['http']['method']) === 'POST'))) {
             $headers['content-type'] = 'application/x-www-form-urlencoded';
         }
 
@@ -222,7 +239,8 @@ class Request
      */
     protected static function ensureContentLengthIsSet(array $event, array $headers, array $serverVariables, $requestBody)
     {
-        if (! in_array(strtoupper($event['httpMethod']), ['TRACE']) && ! isset($headers['content-length'])) {
+        if ((! isset($headers['content-length']) && isset($event['httpMethod']) && !in_array(strtoupper($event['httpMethod']), ['TRACE'])) ||
+            (! isset($headers['content-length']) && isset($event['requestContext']['http']['method']) && !in_array(strtoupper($event['requestContext']['http']['method']), ['TRACE']))) {
             $headers['content-length'] = strlen($requestBody);
         }
 
@@ -244,6 +262,10 @@ class Request
     {
         if (isset($event['requestContext']['identity']['sourceIp'])) {
             $headers['x-vapor-source-ip'] = $event['requestContext']['identity']['sourceIp'];
+        }
+
+        if (isset($event['requestContext']['http']['sourceIp'])) {
+            $headers['x-vapor-source-ip'] = $event['requestContext']['http']['sourceIp'];
         }
 
         return $headers;

--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -72,7 +72,7 @@ class Request
             'SERVER_ADDR' => '127.0.0.1',
             'SERVER_NAME' => $headers['host'] ?? 'localhost',
             'SERVER_PORT' => $headers['x-forwarded-port'] ?? 80,
-            'SERVER_PROTOCOL' =>  $event['requestContext']['protocol'] ?? $event['requestContext']['http']['protocol'] ??'HTTP/1.1',
+            'SERVER_PROTOCOL' =>  $event['requestContext']['protocol'] ?? $event['requestContext']['http']['protocol'] ?? 'HTTP/1.1',
             'SERVER_SOFTWARE' => 'vapor',
         ]);
 

--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -61,7 +61,7 @@ class Request
 
         $serverVariables = array_merge($serverVariables, [
             'GATEWAY_INTERFACE' => 'FastCGI/1.0',
-            'PATH_INFO' => $event['path'] ??  $event['requestContext']['http']['path'] ?? '/',
+            'PATH_INFO' => $event['path'] ?? $event['requestContext']['http']['path'] ?? '/',
             'QUERY_STRING' => $queryString,
             'REMOTE_ADDR' => '127.0.0.1',
             'REMOTE_PORT' => $headers['x-forwarded-port'] ?? 80,
@@ -236,8 +236,8 @@ class Request
      */
     protected static function ensureContentLengthIsSet(array $event, array $headers, array $serverVariables, $requestBody)
     {
-        if ((! isset($headers['content-length']) && isset($event['httpMethod']) && !in_array(strtoupper($event['httpMethod']), ['TRACE'])) ||
-            (! isset($headers['content-length']) && isset($event['requestContext']['http']['method']) && !in_array(strtoupper($event['requestContext']['http']['method']), ['TRACE']))) {
+        if ((! isset($headers['content-length']) && isset($event['httpMethod']) && ! in_array(strtoupper($event['httpMethod']), ['TRACE'])) ||
+            (! isset($headers['content-length']) && isset($event['requestContext']['http']['method']) && ! in_array(strtoupper($event['requestContext']['http']['method']), ['TRACE']))) {
             $headers['content-length'] = strlen($requestBody);
         }
 

--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -131,7 +131,11 @@ class Request
             return http_build_query(
                 collect($event['queryStringParameters'] ?? [])
                 ->mapWithKeys(function ($value, $key) {
-                    return [$key => explode(',', $value)];
+                    $values = explode(',', $value);
+
+                    return count($values) === 1
+                        ? [$key => $values[0]]
+                        : [(substr($key, -2) == '[]' ? substr($key, 0, -2) : $key) => $values];
                 })->all()
             );
         }

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -41,7 +41,7 @@ class FpmRequestTest extends TestCase
                 'X-Amzn-Trace-Id' => $trace,
                 'X-Forwarded-For' => $for,
                 'X-Forwarded-Port' => $port,
-                'X-Forwarded-Proto' => $port,
+                'X-Forwarded-Proto' => $proto,
             ],
             'multiValueHeaders' => [
                 'X-Amzn-Trace-Id' => [
@@ -65,6 +65,61 @@ class FpmRequestTest extends TestCase
         $this->assertSame($for, $request->serverVariables['HTTP_X_FORWARDED_FOR']);
         $this->assertSame($port, $request->serverVariables['HTTP_X_FORWARDED_PORT']);
         $this->assertSame($proto, $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
+    }
+
+    public function test_api_gateway_v2_headers_are_handled()
+    {
+        $trace = 'Root=1-7696740c-c075312a25f21abe1ca19805;foobar';
+        $for = '172.105.167.153, 70.132.20.166';
+        $port = '443';
+        $proto = 'https';
+
+        $request = FpmRequest::fromLambdaEvent([
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'protocol' => 'HTTP/1.1',
+                ],
+            ],
+            'headers' => [
+                'x-amzn-trace-id' => $trace,
+                'x-forwarded-for' => $for,
+                'x-forwarded-port' => $port,
+                'x-forwarded-proto' => $proto,
+            ],
+            'queryStringParameters' => null,
+        ]);
+
+        $this->assertSame($trace, $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
+        $this->assertSame($for, $request->serverVariables['HTTP_X_FORWARDED_FOR']);
+        $this->assertSame($port, $request->serverVariables['HTTP_X_FORWARDED_PORT']);
+        $this->assertSame($proto, $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
+    }
+
+    public function test_api_gateway_v2_query_parameters_are_handled()
+    {
+        $request = FpmRequest::fromLambdaEvent([
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'protocol' => 'HTTP/1.1',
+                ],
+            ],
+            'queryStringParameters' => [
+                'key1' => 'value1',
+                'key2' => 'value2,value3',
+            ],
+        ]);
+
+        $this->assertSame(
+            http_build_query([
+                'key1' => 'value1',
+                'key2' => ['value2', 'value3'],
+            ]),
+            $request->serverVariables['QUERY_STRING']
+        );
     }
 
     public function test_load_balancer_headers_are_over_spoofed_headers()


### PR DESCRIPTION
Add support to the `vapor/core` runtime to accept event payloads received in the 2.0 version of the Lambda Proxy Integration. 

https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html

Without these changes `Laravel\Vapor\Runtime\Handlers\UnknownEventHandler::class` will return `'Unknown event type.'`

The motivation for this change is to allow Vapor Lambda functions to be invoked via Function URLs without having to use API Gateway or Application Load Balancer.

https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html