### PR TITLE
Allow additional Redis config in config/database.php

### DIFF
--- a/src/ConfiguresRedis.php
+++ b/src/ConfiguresRedis.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Vapor;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
 
 trait ConfiguresRedis
@@ -17,7 +18,7 @@ trait ConfiguresRedis
             return;
         }
 
-        Config::set('database.redis', [
+        Config::set('database.redis', array_merge(Arr::except(Config::get('database.redis', []), ['default', 'cache']), [
             'client' => $_ENV['REDIS_CLIENT'] ?? 'phpredis',
             'options' => array_merge(Config::get('database.redis.options', []), [
                 'cluster' => $_ENV['REDIS_CLUSTER'] ?? 'redis',
@@ -40,6 +41,6 @@ trait ConfiguresRedis
                     ],
                 ],
             ]),
-        ]);
+        ]));
     }
 }


### PR DESCRIPTION
Vapor currently overwrites and ignores any additional config for Redis. The only way to override this is to set `VAPOR_CACHE=false` and to update the config/database.php to match the setup in this file.

This PR allows for any additional Redis database config to be merged in without affecting the existing cluster config conversion for Vapor.

A use case for this is when you want to configure a non-clustered Redis instance for WebSockets outside of Vapor.

eg This config in Laravel;
```
    'redis' => [

        'client' => env('REDIS_CLIENT', 'phpredis'),

        'options' => [
            'cluster' => env('REDIS_CLUSTER', 'redis'),
            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
        ],

        'default' => [
                'host' => env('REDIS_HOST', '127.0.0.1'),
                'password' => env('REDIS_PASSWORD', null),
                'port' => env('REDIS_PORT', 6379),
                'database' => env('REDIS_DB', 0),
        ],

        'cache' => [
                'host' => env('REDIS_HOST', '127.0.0.1'),
                'password' => env('REDIS_PASSWORD', null),
                'port' => env('REDIS_PORT', 6379),
                'database' => env('REDIS_CACHE_DB', 1),
        ],

        'websockets' => [
            'host' => env('REDIS_WS_HOST', '127.0.0.1'),
            'password' => env('REDIS_PASSWORD', null),
            'port' => env('REDIS_PORT', 6379),
            'database' => env('REDIS_DB', 0),
        ],

    ],
```

Would be converted to this in Vapor;
```
    'redis' => [

        'client' => env('REDIS_CLIENT', 'phpredis'),

        'options' => [
            'cluster' => env('REDIS_CLUSTER', 'redis'),
            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
        ],

        'clusters' => [

            'default' => [
                [
                    'host' => env('REDIS_HOST', '127.0.0.1'),
                    'password' => null,
                    'port' => 6379,
                    'database' => 0,
                ],
            ],

            'cache' => [
                [
                    'host' => env('REDIS_HOST', '127.0.0.1'),
                    'password' => null,
                    'port' => 6379,
                    'database' => 0,
                ],
            ],

        ],

    ],
```

With this PR, the config would look like this;
```
    'redis' => [

        'client' => env('REDIS_CLIENT', 'phpredis'),

        'options' => [
            'cluster' => env('REDIS_CLUSTER', 'redis'),
            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
        ],

        'clusters' => [

            'default' => [
                [
                    'host' => env('REDIS_HOST', '127.0.0.1'),
                    'password' => null,
                    'port' => 6379,
                    'database' => 0,
                ],
            ],

            'cache' => [
                [
                    'host' => env('REDIS_HOST', '127.0.0.1'),
                    'password' => null,
                    'port' => 6379,
                    'database' => 0,
                ],
            ],

        ],

        'websockets' => [
            'host' => env('REDIS_WS_HOST', '127.0.0.1'),
            'password' => env('REDIS_PASSWORD', null),
            'port' => env('REDIS_PORT', 6379),
            'database' => env('REDIS_DB', 0),
        ],

    ],
```
