### PR TITLE
Adds more tests regarding Vapor's Lambda proxy integration

### DIFF
--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -174,15 +174,16 @@ class Request
      */
     protected static function getHeaders(array $event)
     {
+        if (isset($event['version']) && $event['version'] === '2.0') {
+            return array_change_key_case(
+                collect($event['headers'] ?? [])
+                    ->mapWithKeys(function ($headers, $name) {
+                        return [$name => Arr::last(explode(',', $headers))];
+                    })->all(), CASE_LOWER
+            );
+        }
+
         if (! isset($event['multiValueHeaders'])) {
-            if (isset($event['version']) && $event['version'] === '2.0' && isset($event['headers'])) {
-                foreach ($event['headers'] as $key => $value) {
-                    $values = explode(',', $value);
-
-                    $event['headers'][$key] = trim($values[count($values) - 1]);
-                }
-            }
-
             return array_change_key_case(
                 $event['headers'] ?? [], CASE_LOWER
             );

--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -175,6 +175,14 @@ class Request
     protected static function getHeaders(array $event)
     {
         if (! isset($event['multiValueHeaders'])) {
+            if (isset($event['version']) && $event['version'] === '2.0' && isset($event['headers'])) {
+                foreach ($event['headers'] as $key => $value) {
+                    $values = explode(',', $value);
+
+                    $event['headers'][$key] = trim($values[count($values) - 1]);
+                }
+            }
+
             return array_change_key_case(
                 $event['headers'] ?? [], CASE_LOWER
             );

--- a/tests/Feature/LambdaProxyOctaneHandlerTest.php
+++ b/tests/Feature/LambdaProxyOctaneHandlerTest.php
@@ -18,7 +18,7 @@ use Laravel\Vapor\Tests\TestCase;
 use Mockery;
 use RuntimeException;
 
-class OctaneHandlerTest extends TestCase
+class LambdaProxyOctaneHandlerTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -58,7 +58,12 @@ class OctaneHandlerTest extends TestCase
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                ],
+            ],
         ]);
 
         static::assertEquals('Hello World', $response->toApiGatewayFormat()['body']);
@@ -73,8 +78,13 @@ class OctaneHandlerTest extends TestCase
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
-            'path' => '/////foo',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/////foo',
+                ],
+            ],
         ]);
 
         static::assertEquals('Hello World', $response->toApiGatewayFormat()['body']);
@@ -91,8 +101,13 @@ class OctaneHandlerTest extends TestCase
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
-            'path' => '/',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/',
+                ],
+            ],
         ]);
 
         static::assertEquals('text/javascript', $response->toApiGatewayFormat()['headers']['Content-Type']);
@@ -108,8 +123,12 @@ class OctaneHandlerTest extends TestCase
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
-            'path' => '/',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                ],
+            ],
         ]);
 
         static::assertEquals('attachment; filename=asset.js', $response->toApiGatewayFormat()['headers']['Content-Disposition']);
@@ -129,7 +148,12 @@ class OctaneHandlerTest extends TestCase
         });
 
         $handler->handle([
-            'httpMethod' => 'GET',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                ],
+            ],
         ]);
 
         Event::assertDispatched(RequestReceived::class);
@@ -147,7 +171,12 @@ class OctaneHandlerTest extends TestCase
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                ],
+            ],
         ]);
 
         static::assertArrayHasKey('Foo', $response->toApiGatewayFormat()['headers']);
@@ -163,7 +192,12 @@ class OctaneHandlerTest extends TestCase
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                ],
+            ],
         ]);
 
         static::assertEquals(500, $response->toApiGatewayFormat()['statusCode']);
@@ -186,13 +220,23 @@ class OctaneHandlerTest extends TestCase
         });
 
         $bindResponse = $handler->handle([
-            'httpMethod' => 'GET',
-            'path' => '/bind',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/bind',
+                ],
+            ],
         ]);
 
         $boundResponse = $handler->handle([
-            'httpMethod' => 'GET',
-            'path' => '/bound',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/bound',
+                ],
+            ],
         ]);
 
         static::assertEquals('1', $bindResponse->toApiGatewayFormat()['body']);
@@ -208,8 +252,13 @@ class OctaneHandlerTest extends TestCase
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
-            'path' => '/',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/',
+                ],
+            ],
         ]);
 
         $setCookie = $response->toApiGatewayFormat()['headers']['set-cookie'];
@@ -228,8 +277,13 @@ class OctaneHandlerTest extends TestCase
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
-            'path' => '/',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/',
+                ],
+            ],
         ]);
 
         $robotsTag = $response->toApiGatewayFormat()['headers']['X-Robots-Tag'];
@@ -249,8 +303,13 @@ class OctaneHandlerTest extends TestCase
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
-            'path' => '/',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/',
+                ],
+            ],
             'headers' => [
                 'Accept' => 'application/json',
             ],
@@ -269,8 +328,13 @@ class OctaneHandlerTest extends TestCase
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'POST',
-            'path' => '/',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'POST',
+                    'path' => '/',
+                ],
+            ],
             'headers' => [
                 'Content-Type' => 'application/json',
             ],
@@ -295,8 +359,13 @@ EOF
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'PUT',
-            'path' => '/',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'PUT',
+                    'path' => '/',
+                ],
+            ],
             'headers' => [
                 'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
             ],
@@ -320,8 +389,13 @@ EOF
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
-            'path' => '/',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/',
+                ],
+            ],
             'headers' => [
                 'cookie' => 'XSRF-TOKEN=token_value',
             ],
@@ -345,8 +419,13 @@ EOF
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'POST',
-            'path' => '/',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'POST',
+                    'path' => '/',
+                ],
+            ],
             'headers' => [
                 'Content-Type' => 'multipart/form-data; boundary=---------------------------317050813134112680482597024243',
             ],
@@ -394,8 +473,13 @@ EOF
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'PUT',
-            'path' => '/',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'PUT',
+                    'path' => '/',
+                ],
+            ],
             'headers' => [
                 'Content-Type' => 'multipart/form-data; boundary=---------------------------317050813134112680482597024243',
             ],
@@ -435,17 +519,23 @@ EOF
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
-            'path' => '/',
-            'multiValueQueryStringParameters' => [
-                'foo' => ['bar'],
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/',
+                ],
+            ],
+            'queryStringParameters' => [
+                'param1' => 'value1',
+                'param2' => 'value1,value2',
             ],
             'headers' => [
                 'cookie' => 'XSRF-TOKEN=token_value',
             ],
         ]);
 
-        static::assertEquals('foo=bar', $response->toApiGatewayFormat()['body']);
+        static::assertEquals('param1=value1&param2[0]=value1&param2[1]=value2', urldecode($response->toApiGatewayFormat()['body']));
     }
 
     public function test_request_query_params()
@@ -457,17 +547,26 @@ EOF
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
-            'path' => '/',
-            'multiValueQueryStringParameters' => [
-                'foo' => ['bar'],
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/',
+                ],
+            ],
+            'queryStringParameters' => [
+                'param1' => 'value1',
+                'param2' => 'value1,value2',
             ],
             'headers' => [
                 'cookie' => 'XSRF-TOKEN=token_value',
             ],
         ]);
 
-        static::assertEquals(['foo' => 'bar'], json_decode($response->toApiGatewayFormat()['body'], true));
+        static::assertEquals([
+            'param1' => 'value1',
+            'param2' => ['value1', 'value2'],
+        ], json_decode($response->toApiGatewayFormat()['body'], true));
     }
 
     public function test_request_headers()
@@ -479,7 +578,13 @@ EOF
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/',
+                ],
+            ],
             'path' => '/',
             'headers' => [
                 'X-Xsrf-Token' => 'my-token',
@@ -489,6 +594,34 @@ EOF
         $body = $response->toApiGatewayFormat()['body'];
 
         static::assertEquals(['my-token'], json_decode($body, true)['x-xsrf-token']);
+    }
+
+    public function test_request_multi_headers()
+    {
+        $handler = new OctaneHandler();
+
+        Route::get('/', function (Request $request) {
+            return $request->headers->all();
+        });
+
+        $response = $handler->handle([
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/',
+                ],
+            ],
+            'headers' => [
+                'X-Xsrf-Token' => 'my-token',
+                'X-Multi-Header' => 'value1,value2',
+            ],
+        ]);
+
+        $body = $response->toApiGatewayFormat()['body'];
+
+        static::assertEquals(['my-token'], json_decode($body, true)['x-xsrf-token']);
+        static::assertEquals(['value2'], json_decode($body, true)['x-multi-header']);
     }
 
     public function test_maintenance_mode_with_valid_bypass_cookie()
@@ -523,8 +656,13 @@ EOF
         });
 
         $response = $handler->response($octane::handle($handler->request([
-            'httpMethod' => 'GET',
-            'path' => '/',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/',
+                ],
+            ],
         ])));
 
         static::assertEquals('Hello World', $response->toApiGatewayFormat()['body']);
@@ -543,8 +681,13 @@ EOF
         });
 
         $response = $handler->handle([
-            'httpMethod' => 'GET',
-            'path' => '/',
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/',
+                ],
+            ],
             'headers' => [
                 'Accept' => 'application/json',
             ],

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -43,28 +43,14 @@ class FpmRequestTest extends TestCase
                 'X-Forwarded-Port' => $port,
                 'X-Forwarded-Proto' => $proto,
             ],
-            'multiValueHeaders' => [
-                'X-Amzn-Trace-Id' => [
-                    $trace,
-                ],
-                'X-Forwarded-For' => [
-                    $for,
-                ],
-                'X-Forwarded-Port' => [
-                    $port,
-                ],
-                'X-Forwarded-Proto' => [
-                    $proto,
-                ],
-            ],
             'queryStringParameters' => null,
             'multiValueQueryStringParameters' => null,
         ]);
 
-        $this->assertSame($trace, $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
-        $this->assertSame($for, $request->serverVariables['HTTP_X_FORWARDED_FOR']);
-        $this->assertSame($port, $request->serverVariables['HTTP_X_FORWARDED_PORT']);
-        $this->assertSame($proto, $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
+        $this->assertSame('Root=1-7696740c-c075312a25f21abe1ca19805;foobar', $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
+        $this->assertSame('70.132.20.166', $request->serverVariables['HTTP_X_FORWARDED_FOR']);
+        $this->assertSame('443', $request->serverVariables['HTTP_X_FORWARDED_PORT']);
+        $this->assertSame('https', $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
     }
 
     public function test_api_gateway_v2_headers_are_handled()
@@ -91,12 +77,10 @@ class FpmRequestTest extends TestCase
             'queryStringParameters' => null,
         ]);
 
-        $this->assertSame($trace, $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
-
-        // Vapor does not support multiple values on the same header...
+        $this->assertSame('Root=1-7696740c-c075312a25f21abe1ca19805;foobar', $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
         $this->assertSame('70.132.20.166', $request->serverVariables['HTTP_X_FORWARDED_FOR']);
-        $this->assertSame($port, $request->serverVariables['HTTP_X_FORWARDED_PORT']);
-        $this->assertSame($proto, $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
+        $this->assertSame('443', $request->serverVariables['HTTP_X_FORWARDED_PORT']);
+        $this->assertSame('https', $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
     }
 
     public function test_api_gateway_v2_query_parameters_are_handled()

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -92,7 +92,9 @@ class FpmRequestTest extends TestCase
         ]);
 
         $this->assertSame($trace, $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
-        $this->assertSame($for, $request->serverVariables['HTTP_X_FORWARDED_FOR']);
+
+        // Vapor does not support multiple values on the same header...
+        $this->assertSame('70.132.20.166', $request->serverVariables['HTTP_X_FORWARDED_FOR']);
         $this->assertSame($port, $request->serverVariables['HTTP_X_FORWARDED_PORT']);
         $this->assertSame($proto, $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
     }

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -30,14 +30,14 @@ class FpmRequestTest extends TestCase
 
     public function test_api_gateway_headers_are_handled()
     {
-        $trace = 'Root=1-7696740c-c075312a25f21abe1ca19805;foobar';
-        $for = '172.105.167.153, 70.132.20.166';
-        $port = '443';
-        $proto = 'https';
+        $trace = ['Root=1-7696740c-c075312a25f21abe1ca19805;foobar'];
+        $for = ['172.105.167.153', '70.132.20.166'];
+        $port = ['443'];
+        $proto = ['https'];
 
         $request = FpmRequest::fromLambdaEvent([
             'httpMethod' => 'GET',
-            'headers' => [
+            'multiValueHeaders' => [
                 'X-Amzn-Trace-Id' => $trace,
                 'X-Forwarded-For' => $for,
                 'X-Forwarded-Port' => $port,
@@ -70,7 +70,7 @@ class FpmRequestTest extends TestCase
     public function test_api_gateway_v2_headers_are_handled()
     {
         $trace = 'Root=1-7696740c-c075312a25f21abe1ca19805;foobar';
-        $for = '172.105.167.153, 70.132.20.166';
+        $for = '172.105.167.153,70.132.20.166';
         $port = '443';
         $proto = 'https';
 


### PR DESCRIPTION
This pull request does two things:

1. Fixes the lambda proxy integration when multiple header values are used. Today, on both API Gateway and Load Balancer, only the last value is preserved. So, we keep doing that behaviour on the lambda proxy integration.
2. Adds a lot of tests.