### PR TITLE
Ignores octane database disconnect error

### DIFF
--- a/src/Runtime/Octane/Octane.php
+++ b/src/Runtime/Octane/Octane.php
@@ -115,7 +115,7 @@ class Octane implements Client
                     try {
                         $connection->disconnect();
                     } catch (Throwable $e) {
-                        // Ignore if errors as it is likely already disconnected.
+                        // Likely already disconnected...
                     }
                 }
 

--- a/src/Runtime/Octane/Octane.php
+++ b/src/Runtime/Octane/Octane.php
@@ -112,7 +112,11 @@ class Octane implements Client
                 $hasSession = in_array($connection->getName(), static::$databaseSessions);
 
                 if (! $hasSession) {
-                    $connection->disconnect();
+                    try {
+                        $connection->disconnect();
+                    } catch (\ErrorException $e) {
+                        // Ignore if errors as it is likely already disconnected.
+                    }
                 }
 
                 return $hasSession;

--- a/src/Runtime/Octane/Octane.php
+++ b/src/Runtime/Octane/Octane.php
@@ -114,7 +114,7 @@ class Octane implements Client
                 if (! $hasSession) {
                     try {
                         $connection->disconnect();
-                    } catch (\ErrorException $e) {
+                    } catch (Throwable $e) {
                         // Ignore if errors as it is likely already disconnected.
                     }
                 }


### PR DESCRIPTION
An error occurs intermittently when octane attempts to disconnect from a database connection that seems to have already been disconnected. This is when using this config:

```yml
octane: true
octane-database-session-persist: true
octane-database-session-ttl: 10
```

Disabling `octane-database-session-persist` stops the error from occurring. 

Example: https://flareapp.io/share/o7AKYNdm#F26

With RDS Proxy enabled the error message is this: 
`PDO::prepare(): SSL: Operation timed out`

Without RDS proxy the`ErrorException` message is:
`Illuminate\Database\Connection::setPdo(): SSL: Broken pipe`

There has been some discussion amongst several vapor users on Jack Ellis's Serverless Laravel Slack vapor community, its a private community but if you have access to it you can find the thread here:
https://app.slack.com/client/T0121FD6NF7/C012BR9G5EE/thread/C012BR9G5EE-1635543359.070100

**We believe that this exception should be ignored and this change simply wraps the disconnect attempt in a try/catch.**

Please find below thoughts from Jack Ellis which I believe they emailed to you but providing here for additional context:
> Hey folks,
> 
> This bug has come up multiple times from a whole bunch of Vapor users now, so I wanted to raise it and try and do a bit of digging myself. This bug will happen multiple times per day and it may have an easy fix.
> 
> I've attached the stack trace below but it seems the errors come from this line when disconnect is called: https://github.com/laravel/vapor-core/blob/6fdd41a5df2ac7ff3c8a56f9a76338ada33657f9/src/Runtime/Octane/Octane.php#L115
> 
> So yeah, this is for Octane with folks using the TTL settings on the database.
> 
> What we have
>  1. The stack trace shows broken pipe. And this code is trying to disconnect from a connect that's already been closed by the database server
>  2. DetectsLostConnections is not being used here because you're calling the disconnect function. You'd normally reconnect when hitting this error, but you are explicitly disconnecting here
>  3. My brain cannot figure out what the above code does, sorry, I'm sick and it's been a long day
> 
> Potential solution
> If the disconnect throws an error, I'd argue that it doesn't matter. Even some kind of try/catch wrapper would stop these errors completely, and you'd still return false. So a try/catch around that disconnect may be the solution here. Meaning, if the connection is alive, it's disconnected. If it's already been killed by the server, no problem, we catch the error. The only *concern* I have would be latency for that Broken Pipe to come back. But that may be a future thing to look into, for now the primary bug is more important.
> 
> Thanks,
> 
> Jack