### PR TITLE
[2.x] Allows comma separated header values in API Gateway format 2.0

### DIFF
--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -72,7 +72,7 @@ class Request
             'SERVER_ADDR' => '127.0.0.1',
             'SERVER_NAME' => $headers['host'] ?? 'localhost',
             'SERVER_PORT' => $headers['x-forwarded-port'] ?? 80,
-            'SERVER_PROTOCOL' =>  $event['requestContext']['protocol'] ?? $event['requestContext']['http']['protocol'] ?? 'HTTP/1.1',
+            'SERVER_PROTOCOL' => $event['requestContext']['protocol'] ?? $event['requestContext']['http']['protocol'] ?? 'HTTP/1.1',
             'SERVER_SOFTWARE' => 'vapor',
         ]);
 
@@ -174,15 +174,6 @@ class Request
      */
     protected static function getHeaders(array $event)
     {
-        if (isset($event['version']) && $event['version'] === '2.0') {
-            return array_change_key_case(
-                collect($event['headers'] ?? [])
-                    ->mapWithKeys(function ($headers, $name) {
-                        return [$name => Arr::last(explode(',', $headers))];
-                    })->all(), CASE_LOWER
-            );
-        }
-
         if (! isset($event['multiValueHeaders'])) {
             return array_change_key_case(
                 $event['headers'] ?? [], CASE_LOWER

--- a/tests/Feature/LambdaProxyOctaneHandlerTest.php
+++ b/tests/Feature/LambdaProxyOctaneHandlerTest.php
@@ -621,7 +621,7 @@ EOF
         $body = $response->toApiGatewayFormat()['body'];
 
         static::assertEquals(['my-token'], json_decode($body, true)['x-xsrf-token']);
-        static::assertEquals(['value2'], json_decode($body, true)['x-multi-header']);
+        static::assertEquals(['value1,value2'], json_decode($body, true)['x-multi-header']);
     }
 
     public function test_maintenance_mode_with_valid_bypass_cookie()

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -78,7 +78,7 @@ class FpmRequestTest extends TestCase
         ]);
 
         $this->assertSame('Root=1-7696740c-c075312a25f21abe1ca19805;foobar', $request->serverVariables['HTTP_X_AMZN_TRACE_ID']);
-        $this->assertSame('70.132.20.166', $request->serverVariables['HTTP_X_FORWARDED_FOR']);
+        $this->assertSame('172.105.167.153,70.132.20.166', $request->serverVariables['HTTP_X_FORWARDED_FOR']);
         $this->assertSame('443', $request->serverVariables['HTTP_X_FORWARDED_PORT']);
         $this->assertSame('https', $request->serverVariables['HTTP_X_FORWARDED_PROTO']);
     }


### PR DESCRIPTION
Sandbox environments use function URLs which utilise API Gateway 2.0 request format. 

Support for this format was added back in May: https://github.com/laravel/vapor-core/pull/129
With an update to the format added here: https://github.com/laravel/vapor-core/pull/131

The second PR description states that we only preserve the last value provided in the value of a header. This presents a problem when processing something such as the signature in a Stripe webhook which is sent as a header in the format:

```
Stripe-Signature:
t=1492774577,
v1=5257a869e7ecebeda32affa62cdca3fa51cad7e77a0e56ff536d0ce8e108d8bd,
v0=6ffbb59b2300aae63f272406069a9788598b792a944a07aba816edb039989a39
```

When we process this header, we explode on the comma and set the header to the last value in the resulting array. In this case we'd end up with the following which means the webhook cannot be verified.

```
Stripe-Signature:
v0=6ffbb59b2300aae63f272406069a9788598b792a944a07aba816edb039989a39
```

Furthermore, I did some testing with API Gateway v1 and v2 and load balanced requests and found the header values to include the comma-separeted values:

**Load balanced response**
<img width="340" alt="Screenshot 2022-09-29 at 11 08 47" src="https://user-images.githubusercontent.com/3438564/193005249-94c08750-271a-4208-b203-8ec5050e54c8.png">

This PR updates the preserves the full header value rather than exploding the comma separated values.


