### PR TITLE
[2.x] Decrypt environment when runtime boots

### DIFF
--- a/src/Runtime/Environment.php
+++ b/src/Runtime/Environment.php
@@ -51,12 +51,29 @@ class Environment
      */
     protected $console;
 
+    /**
+     * Create a new environment manager instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
     public function __construct(Application $app)
     {
         $this->app = $app;
+
         $this->environment = $_ENV['APP_ENV'] ?? 'production';
         $this->environmentFile = '.env.'.$this->environment;
         $this->encryptedFile = '.env.'.$this->environment.'.encrypted';
+    }
+
+    /**
+     * Decrypt the environment file and load it into the runtime.
+     *
+     * @return void
+     */
+    public static function decrypt($app)
+    {
+        (new static($app))->decryptEnvironment();
     }
 
     /**
@@ -88,17 +105,7 @@ class Environment
     }
 
     /**
-     * Decrypt the environment file and load it into the runtime.
-     *
-     * @return void
-     */
-    public static function decrypt($app)
-    {
-        (new static($app))->decryptEnvironment();
-    }
-
-    /**
-     * Determine if it is possible to decrypt an environment file.
+     * Determine if it is possible to decrypt the environment file.
      *
      * @return bool
      */
@@ -163,7 +170,7 @@ class Environment
     }
 
     /**
-     * Get a console kernel instance.
+     * Get the console kernel implementation.
      *
      * @return \Illuminate\Contracts\Console\Kernel
      */

--- a/src/Runtime/Environment.php
+++ b/src/Runtime/Environment.php
@@ -38,7 +38,7 @@ class Environment
     protected $environmentFile;
 
     /**
-     * The encrypted environment file name
+     * The encrypted environment file name.
      *
      * @var string
      */

--- a/src/Runtime/Environment.php
+++ b/src/Runtime/Environment.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Laravel\Vapor\Runtime;
+
+use Dotenv\Dotenv;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+class Environment
+{
+    /**
+     * Decrypt and encrypted environment file into the runtime.
+     *
+     * @return void
+     */
+    public static function decrypt()
+    {
+        if (static::cannotBeDecrypted()) {
+            return;
+        }
+
+        $basePath = app()->basePath();
+
+        File::copy(static::encryptedFilePath(), '/tmp/'.static::encryptedFile());
+
+        app()->setBasePath('/tmp');
+
+        app()->make(ConsoleKernelContract::class)->call('env:decrypt', ['--env' => static::environment()]);
+
+        Dotenv::createImmutable(app()->basePath(), static::environmentFile())->load();
+
+        app()->setBasePath($basePath);
+    }
+
+    /**
+     * Determine if it is possible to decrypt an environment file.
+     *
+     * @return bool
+     */
+    public static function canBeDecrypted()
+    {
+        if (! isset($_ENV['LARAVEL_ENV_ENCRYPTION_KEY'])) {
+            fwrite(STDERR, 'No decryption key set.'.PHP_EOL);
+
+            return false;
+        }
+
+        if (! in_array('env:decrypt', array_keys(Artisan::all()))) {
+            fwrite(STDERR, 'Decrypt command not available.'.PHP_EOL);
+
+            return false;
+        }
+
+        if (! File::exists(app()->basePath(static::encryptedFile()))) {
+            fwrite(STDERR, 'Encrypted environment file not found.'.PHP_EOL);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine is it is not possible to decrypt an environment.
+     *
+     * @return bool
+     */
+    public static function cannotBeDecrypted()
+    {
+        return ! static::canBeDecrypted();
+    }
+
+    /**
+     * Returns the current environment.
+     *
+     * @return string
+     */
+    public static function environment()
+    {
+        return isset($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : 'production';
+    }
+
+    /**
+     * Returns the environment file name for the current environment.
+     *
+     * @return string
+     */
+    public static function environmentFile()
+    {
+        return '.env.'.static::environment();
+    }
+
+    /**
+     * Returns the encrypted file name for the current environment.
+     *
+     * @return string
+     */
+    public static function encryptedFile()
+    {
+        return static::environmentFile().'.encrypted';
+    }
+
+    /**
+     * Returns the full path to the encrypted file for the current environment.
+     *
+     * @return string
+     */
+    public static function encryptedFilePath()
+    {
+        return app()->basePath(static::encryptedFile());
+    }
+}

--- a/src/Runtime/Environment.php
+++ b/src/Runtime/Environment.php
@@ -54,7 +54,7 @@ class Environment
     public function __construct(Application $app)
     {
         $this->app = $app;
-        $this->environment = isset($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : 'production';
+        $this->environment = $_ENV['APP_ENV'] ?? 'production';
         $this->environmentFile = '.env.'.$this->environment;
         $this->encryptedFile = '.env.'.$this->environment.'.encrypted';
     }

--- a/stubs/cliRuntime.php
+++ b/stubs/cliRuntime.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Laravel\Vapor\Runtime\CliHandlerFactory;
+use Laravel\Vapor\Runtime\Environment;
 use Laravel\Vapor\Runtime\LambdaContainer;
 use Laravel\Vapor\Runtime\LambdaRuntime;
 use Laravel\Vapor\Runtime\Secrets;
@@ -53,6 +54,21 @@ with(require __DIR__.'/bootstrap/app.php', function ($app) {
         echo 'Failing caching Laravel configuration: '.$e->getMessage().PHP_EOL;
     }
 });
+
+/*
+|--------------------------------------------------------------------------
+| Inject decrypted environment variables
+|--------------------------------------------------------------------------
+|
+| Next, we will check to see whether a decryption key has been set on the
+| environment. If so, we will attempt to discover an encrypted file at
+| the root of the application and decrypt it into the Vapor runtime.
+|
+*/
+
+fwrite(STDERR, 'Attempting to decrypt environment variables into runtime'.PHP_EOL);
+
+Environment::decrypt();
 
 /*
 |--------------------------------------------------------------------------

--- a/stubs/cliRuntime.php
+++ b/stubs/cliRuntime.php
@@ -29,7 +29,7 @@ Secrets::addToEnvironment(
 
 /*
 |--------------------------------------------------------------------------
-| Inject decrypted environment variables
+| Inject Decrypted Environment Variables
 |--------------------------------------------------------------------------
 |
 | Next, we will check to see whether a decryption key has been set on the

--- a/stubs/fpmRuntime.php
+++ b/stubs/fpmRuntime.php
@@ -32,7 +32,7 @@ $secrets = Secrets::addToEnvironment(
 
 /*
 |--------------------------------------------------------------------------
-| Inject decrypted environment variables
+| Inject Decrypted Environment Variables
 |--------------------------------------------------------------------------
 |
 | Next, we will check to see whether a decryption key has been set on the

--- a/stubs/fpmRuntime.php
+++ b/stubs/fpmRuntime.php
@@ -9,6 +9,8 @@ use Laravel\Vapor\Runtime\LambdaRuntime;
 use Laravel\Vapor\Runtime\Secrets;
 use Laravel\Vapor\Runtime\StorageDirectories;
 
+$app = require __DIR__.'/bootstrap/app.php';
+
 /*
 |--------------------------------------------------------------------------
 | Inject SSM Secrets Into Environment
@@ -30,27 +32,6 @@ $secrets = Secrets::addToEnvironment(
 
 /*
 |--------------------------------------------------------------------------
-| Cache Configuration
-|--------------------------------------------------------------------------
-|
-| To give the application a speed boost, we are going to cache all of the
-| configuration files into a single file. The file will be loaded once
-| by the runtime then it will read the configuration values from it.
-|
-*/
-
-with(require __DIR__.'/bootstrap/app.php', function ($app) {
-    StorageDirectories::create();
-
-    $app->useStoragePath(StorageDirectories::PATH);
-
-    fwrite(STDERR, 'Caching Laravel configuration'.PHP_EOL);
-
-    $app->make(ConsoleKernelContract::class)->call('config:cache');
-});
-
-/*
-|--------------------------------------------------------------------------
 | Inject decrypted environment variables
 |--------------------------------------------------------------------------
 |
@@ -62,7 +43,26 @@ with(require __DIR__.'/bootstrap/app.php', function ($app) {
 
 fwrite(STDERR, 'Attempting to decrypt environment variables into runtime'.PHP_EOL);
 
-Environment::decrypt();
+Environment::decrypt($app);
+
+/*
+|--------------------------------------------------------------------------
+| Cache Configuration
+|--------------------------------------------------------------------------
+|
+| To give the application a speed boost, we are going to cache all of the
+| configuration files into a single file. The file will be loaded once
+| by the runtime then it will read the configuration values from it.
+|
+*/
+
+StorageDirectories::create();
+
+$app->useStoragePath(StorageDirectories::PATH);
+
+fwrite(STDERR, 'Caching Laravel configuration'.PHP_EOL);
+
+$app->make(ConsoleKernelContract::class)->call('config:cache');
 
 /*
 |--------------------------------------------------------------------------

--- a/stubs/octaneRuntime.php
+++ b/stubs/octaneRuntime.php
@@ -32,7 +32,7 @@ $secrets = Secrets::addToEnvironment(
 
 /*
 |--------------------------------------------------------------------------
-| Inject decrypted environment variables
+| Inject Decrypted Environment Variables
 |--------------------------------------------------------------------------
 |
 | Next, we will check to see whether a decryption key has been set on the

--- a/stubs/octaneRuntime.php
+++ b/stubs/octaneRuntime.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
+use Laravel\Vapor\Runtime\Environment;
 use Laravel\Vapor\Runtime\LambdaContainer;
 use Laravel\Vapor\Runtime\LambdaRuntime;
 use Laravel\Vapor\Runtime\Octane\Octane;
@@ -47,6 +48,21 @@ with(require __DIR__.'/bootstrap/app.php', function ($app) {
 
     $app->make(ConsoleKernelContract::class)->call('config:cache');
 });
+
+/*
+|--------------------------------------------------------------------------
+| Inject decrypted environment variables
+|--------------------------------------------------------------------------
+|
+| Next, we will check to see whether a decryption key has been set on the
+| environment. If so, we will attempt to discover an encrypted file at
+| the root of the application and decrypt it into the Vapor runtime.
+|
+*/
+
+fwrite(STDERR, 'Attempting to decrypt environment variables into runtime'.PHP_EOL);
+
+Environment::decrypt();
 
 /*
 |--------------------------------------------------------------------------

--- a/stubs/octaneRuntime.php
+++ b/stubs/octaneRuntime.php
@@ -9,6 +9,8 @@ use Laravel\Vapor\Runtime\Octane\OctaneHttpHandlerFactory;
 use Laravel\Vapor\Runtime\Secrets;
 use Laravel\Vapor\Runtime\StorageDirectories;
 
+$app = require __DIR__.'/bootstrap/app.php';
+
 /*
 |--------------------------------------------------------------------------
 | Inject SSM Secrets Into Environment
@@ -30,27 +32,6 @@ $secrets = Secrets::addToEnvironment(
 
 /*
 |--------------------------------------------------------------------------
-| Cache Configuration
-|--------------------------------------------------------------------------
-|
-| To give the application a speed boost, we are going to cache all of the
-| configuration files into a single file. The file will be loaded once
-| by the runtime then it will read the configuration values from it.
-|
-*/
-
-with(require __DIR__.'/bootstrap/app.php', function ($app) {
-    StorageDirectories::create();
-
-    $app->useStoragePath(StorageDirectories::PATH);
-
-    fwrite(STDERR, 'Caching Laravel configuration'.PHP_EOL);
-
-    $app->make(ConsoleKernelContract::class)->call('config:cache');
-});
-
-/*
-|--------------------------------------------------------------------------
 | Inject decrypted environment variables
 |--------------------------------------------------------------------------
 |
@@ -62,7 +43,26 @@ with(require __DIR__.'/bootstrap/app.php', function ($app) {
 
 fwrite(STDERR, 'Attempting to decrypt environment variables into runtime'.PHP_EOL);
 
-Environment::decrypt();
+Environment::decrypt($app);
+
+/*
+|--------------------------------------------------------------------------
+| Cache Configuration
+|--------------------------------------------------------------------------
+|
+| To give the application a speed boost, we are going to cache all of the
+| configuration files into a single file. The file will be loaded once
+| by the runtime then it will read the configuration values from it.
+|
+*/
+
+StorageDirectories::create();
+
+$app->useStoragePath(StorageDirectories::PATH);
+
+fwrite(STDERR, 'Caching Laravel configuration'.PHP_EOL);
+
+$app->make(ConsoleKernelContract::class)->call('config:cache');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Feature/ApiGatewayOctaneHandlerTest.php
+++ b/tests/Feature/ApiGatewayOctaneHandlerTest.php
@@ -86,7 +86,7 @@ class ApiGatewayOctaneHandlerTest extends TestCase
 
         Route::get('/', function (Request $request) {
             return response()->file(__DIR__.'/../Fixtures/asset.js', [
-                'Content-Type' => 'text/javascript',
+                'Content-Type' => 'text/javascript; charset=UTF-8',
             ]);
         });
 
@@ -95,7 +95,7 @@ class ApiGatewayOctaneHandlerTest extends TestCase
             'path' => '/',
         ]);
 
-        static::assertEquals('text/javascript', $response->toApiGatewayFormat()['headers']['Content-Type']);
+        static::assertEquals('text/javascript; charset=UTF-8', $response->toApiGatewayFormat()['headers']['Content-Type']);
         static::assertEquals("console.log();\n", $response->toApiGatewayFormat()['body']);
     }
 

--- a/tests/Feature/LambdaProxyOctaneHandlerTest.php
+++ b/tests/Feature/LambdaProxyOctaneHandlerTest.php
@@ -96,7 +96,7 @@ class LambdaProxyOctaneHandlerTest extends TestCase
 
         Route::get('/', function (Request $request) {
             return response()->file(__DIR__.'/../Fixtures/asset.js', [
-                'Content-Type' => 'text/javascript',
+                'Content-Type' => 'text/javascript; charset=UTF-8',
             ]);
         });
 
@@ -110,7 +110,7 @@ class LambdaProxyOctaneHandlerTest extends TestCase
             ],
         ]);
 
-        static::assertEquals('text/javascript', $response->toApiGatewayFormat()['headers']['Content-Type']);
+        static::assertEquals('text/javascript; charset=UTF-8', $response->toApiGatewayFormat()['headers']['Content-Type']);
         static::assertEquals("console.log();\n", $response->toApiGatewayFormat()['body']);
     }
 

--- a/tests/Feature/LoadBalancedOctaneHandlerTest.php
+++ b/tests/Feature/LoadBalancedOctaneHandlerTest.php
@@ -106,7 +106,7 @@ class LoadBalancedOctaneHandlerTest extends TestCase
 
         Route::get('/', function (Request $request) {
             return response()->file(__DIR__.'/../Fixtures/asset.js', [
-                'Content-Type' => 'text/javascript',
+                'Content-Type' => 'text/javascript; charset=UTF-8',
             ]);
         });
 
@@ -115,7 +115,7 @@ class LoadBalancedOctaneHandlerTest extends TestCase
             'path' => '/',
         ]);
 
-        static::assertEquals(['text/javascript'], $response->toApiGatewayFormat()['multiValueHeaders']['Content-Type']);
+        static::assertEquals(['text/javascript; charset=UTF-8'], $response->toApiGatewayFormat()['multiValueHeaders']['Content-Type']);
         static::assertEquals("console.log();\n", $response->toApiGatewayFormat()['body']);
     }
 


### PR DESCRIPTION
### Description

This PR adds support for injecting environment variables into the Vapor runtime and can be used in place of or alongside both Vapor environment variables and/or secrets stored on AWS.

It leverages the new `env:decrypt` command introduced in Laravel 9.32.0: https://github.com/laravel/framework/pull/44034

When the runtime is instantiated, Vapor will look for the presence of the `LARAVEL_ENV_ENCRYPTION_KEY` environment variable.

If it exists, an attempt will be made to decrypt the encrypted file for the current environment.

This uses Dotenv to load the environment variables without overriding the existing. Variables are loaded in the following order:

- Enviroment variables added by Vapor and by the user via the Vapor UI
- Secrets (which overwrite duplicate variables)
- Decrypted environment variables (which don't overwrite existing variables)

For example, if the `APP_ENV` is set to `production`, a call to `env:decrypt --env=production` will be run. Under the hood, the command will attempt to decrypt the file called `.env.production.encrypted`.

Assuming the file is found and succesfully decrypted, the variables are loaded into the runtime using Dotenv.

I made the decision to do this as part of the runtime rather than decrypting the file as part of the deployment for two reasons:

1. It prevents the variables becoming part of the deployment artifact
2. It mirrors the way we currently handle secrets.

_____

### Usage

Usage is extremely simple.

1. Upgrade application to Laravel >= 9.32.0
2. Encrypt the environment file for the releveant environment: `php artisan env:ecrypt --env=production`
3. Add the `LARAVEL_ENV_ENCRYPTION_KEY` environment variable in the Vapor UI and set it's value to the key output from the command in step 1
4. Deploy!

_____

### Benchmarking

I carried out some benchmarking to see if this would result in a performance hit.

The first set of tests were performed against a vanilla Laravel application using the latest stable version of vapor-core. The following command was run:

```shell
wrk -t1 -c1 -d20 https://twilight-abyss-4jp7cxqapxbp.vapor-farm-f1.com
```

| **Request #** | **Response (ms)** | **Memory (MB)** |
|---------------|-------------------:|-----------------:|
| Boot          | 639.74            | 159             |
| 1             | 7.42              | 159             |
| 2             | 7.25              | 159             |
| 3             | 7.31              | 159             |
| 4             | 7.44              | 159             |
| 5             | 7.58              | 159             |
| 6             | 7.45              | 159             |
| 7             | 7.48              | 159             |
| 8             | 7.73              | 159             |
| 9             | 7.37              | 159             |
| 10            | 7.72              | 159             |
| **Average**       | **7.475**             | **159**             |

Then the same command was run against a vanilla Laravel application using this branch of vapor-core and with an environment to decrypt.

| **Request #** | **Response (ms)** | **Memory (MB)** |
|---------------|-------------------:|-----------------:|
| Decrypt Boot  | 685.35            | 160             |
| 1             | 7.62              | 160             |
| 2             | 8.05              | 160             |
| 3             | 7.85              | 160             |
| 4             | 9.51              | 160             |
| 5             | 7.77              | 160             |
| 6             | 7.78              | 160             |
| 7             | 7.95              | 160             |
| 8             | 7.96              | 160             |
| 9             | 7.51              | 160             |
| 10            | 7.69              | 160             |
| **Average**       | **7.969**             | **160**             |


As you can see, the differences are quite negligible.