### PR TITLE
[2.x] Automatically cache routes

### DIFF
--- a/src/Runtime/Environment.php
+++ b/src/Runtime/Environment.php
@@ -38,7 +38,7 @@ class Environment
     protected $environmentFile;
 
     /**
-     * The encrypted environment file name
+     * The encrypted environment file name.
      *
      * @var string
      */

--- a/src/Runtime/Environment.php
+++ b/src/Runtime/Environment.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Laravel\Vapor\Runtime;
+
+use Dotenv\Dotenv;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+class Environment
+{
+    /**
+     * Decrypt and encrypted environment file into the runtime.
+     *
+     * @return void
+     */
+    public static function decrypt()
+    {
+        if (static::cannotBeDecrypted()) {
+            return;
+        }
+
+        $basePath = app()->basePath();
+
+        File::copy(static::encryptedFilePath(), '/tmp/'.static::encryptedFile());
+
+        app()->setBasePath('/tmp');
+
+        app()->make(ConsoleKernelContract::class)->call('env:decrypt', ['--env' => static::environment()]);
+
+        Dotenv::createImmutable(app()->basePath(), static::environmentFile())->load();
+
+        app()->setBasePath($basePath);
+    }
+
+    /**
+     * Determine if it is possible to decrypt an environment file.
+     *
+     * @return bool
+     */
+    public static function canBeDecrypted()
+    {
+        if (! isset($_ENV['LARAVEL_ENV_ENCRYPTION_KEY'])) {
+            fwrite(STDERR, 'No decryption key set.'.PHP_EOL);
+
+            return false;
+        }
+
+        if (! in_array('env:decrypt', array_keys(Artisan::all()))) {
+            fwrite(STDERR, 'Decrypt command not available.'.PHP_EOL);
+
+            return false;
+        }
+
+        if (! File::exists(app()->basePath(static::encryptedFile()))) {
+            fwrite(STDERR, 'Encrypted environment file not found.'.PHP_EOL);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine is it is not possible to decrypt an environment.
+     *
+     * @return bool
+     */
+    public static function cannotBeDecrypted()
+    {
+        return ! static::canBeDecrypted();
+    }
+
+    /**
+     * Returns the current environment.
+     *
+     * @return string
+     */
+    public static function environment()
+    {
+        return isset($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : 'production';
+    }
+
+    /**
+     * Returns the environment file name for the current environment.
+     *
+     * @return string
+     */
+    public static function environmentFile()
+    {
+        return '.env.'.static::environment();
+    }
+
+    /**
+     * Returns the encrypted file name for the current environment.
+     *
+     * @return string
+     */
+    public static function encryptedFile()
+    {
+        return static::environmentFile().'.encrypted';
+    }
+
+    /**
+     * Returns the full path to the encrypted file for the current environment.
+     *
+     * @return string
+     */
+    public static function encryptedFilePath()
+    {
+        return app()->basePath(static::encryptedFile());
+    }
+}

--- a/src/Runtime/Environment.php
+++ b/src/Runtime/Environment.php
@@ -54,7 +54,7 @@ class Environment
     public function __construct(Application $app)
     {
         $this->app = $app;
-        $this->environment = isset($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : 'production';
+        $this->environment = $_ENV['APP_ENV'] ?? 'production';
         $this->environmentFile = '.env.'.$this->environment;
         $this->encryptedFile = '.env.'.$this->environment.'.encrypted';
     }

--- a/stubs/cliRuntime.php
+++ b/stubs/cliRuntime.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Laravel\Vapor\Runtime\CliHandlerFactory;
+use Laravel\Vapor\Runtime\Environment;
 use Laravel\Vapor\Runtime\LambdaContainer;
 use Laravel\Vapor\Runtime\LambdaRuntime;
 use Laravel\Vapor\Runtime\Secrets;
@@ -53,6 +54,21 @@ with(require __DIR__.'/bootstrap/app.php', function ($app) {
         echo 'Failing caching Laravel configuration: '.$e->getMessage().PHP_EOL;
     }
 });
+
+/*
+|--------------------------------------------------------------------------
+| Inject decrypted environment variables
+|--------------------------------------------------------------------------
+|
+| Next, we will check to see whether a decryption key has been set on the
+| environment. If so, we will attempt to discover an encrypted file at
+| the root of the application and decrypt it into the Vapor runtime.
+|
+*/
+
+fwrite(STDERR, 'Attempting to decrypt environment variables into runtime'.PHP_EOL);
+
+Environment::decrypt();
 
 /*
 |--------------------------------------------------------------------------

--- a/stubs/fpmRuntime.php
+++ b/stubs/fpmRuntime.php
@@ -11,6 +11,8 @@ use Laravel\Vapor\Runtime\StorageDirectories;
 
 $app = require __DIR__.'/bootstrap/app.php';
 
+$console = $app->make(ConsoleKernelContract::class);
+
 /*
 |--------------------------------------------------------------------------
 | Inject SSM Secrets Into Environment
@@ -62,7 +64,24 @@ $app->useStoragePath(StorageDirectories::PATH);
 
 fwrite(STDERR, 'Caching Laravel configuration'.PHP_EOL);
 
-$app->make(ConsoleKernelContract::class)->call('config:cache');
+$console->call('config:cache');
+
+/*
+|--------------------------------------------------------------------------
+| Cache Routes
+|--------------------------------------------------------------------------
+|
+| To further boost performance, we will attempt to cache the routes of the
+| application. Doing so will drastically decrease the amount of time it
+| takes to register all of the routes when firing up the application.
+|
+*/
+
+if (in_array('route:cache', array_keys($console->all()))) {
+    fwrite(STDERR, 'Caching Laravel routes'.PHP_EOL);
+
+    $console->call('route:cache');
+}
 
 /*
 |--------------------------------------------------------------------------

--- a/stubs/fpmRuntime.php
+++ b/stubs/fpmRuntime.php
@@ -77,7 +77,11 @@ $console->call('config:cache');
 |
 */
 
-if (version_compare($app->version(), '8.0', '>=')) {
+if (
+    version_compare($app->version(), '8.0', '>=')
+        && isset($_ENV['VAPOR_CACHE_ROUTES'])
+        && $_ENV['VAPOR_CACHE_ROUTES'] === 'true'
+) {
     fwrite(STDERR, 'Caching Laravel routes'.PHP_EOL);
 
     $console->call('route:cache');

--- a/stubs/fpmRuntime.php
+++ b/stubs/fpmRuntime.php
@@ -77,7 +77,7 @@ $console->call('config:cache');
 |
 */
 
-if (in_array('route:cache', array_keys($console->all()))) {
+if (version_compare($app->version(), '8.0', '>=')) {
     fwrite(STDERR, 'Caching Laravel routes'.PHP_EOL);
 
     $console->call('route:cache');

--- a/stubs/fpmRuntime.php
+++ b/stubs/fpmRuntime.php
@@ -9,6 +9,8 @@ use Laravel\Vapor\Runtime\LambdaRuntime;
 use Laravel\Vapor\Runtime\Secrets;
 use Laravel\Vapor\Runtime\StorageDirectories;
 
+$app = require __DIR__.'/bootstrap/app.php';
+
 /*
 |--------------------------------------------------------------------------
 | Inject SSM Secrets Into Environment
@@ -30,27 +32,6 @@ $secrets = Secrets::addToEnvironment(
 
 /*
 |--------------------------------------------------------------------------
-| Cache Configuration
-|--------------------------------------------------------------------------
-|
-| To give the application a speed boost, we are going to cache all of the
-| configuration files into a single file. The file will be loaded once
-| by the runtime then it will read the configuration values from it.
-|
-*/
-
-with(require __DIR__.'/bootstrap/app.php', function ($app) {
-    StorageDirectories::create();
-
-    $app->useStoragePath(StorageDirectories::PATH);
-
-    fwrite(STDERR, 'Caching Laravel configuration'.PHP_EOL);
-
-    $app->make(ConsoleKernelContract::class)->call('config:cache');
-});
-
-/*
-|--------------------------------------------------------------------------
 | Inject decrypted environment variables
 |--------------------------------------------------------------------------
 |
@@ -62,7 +43,26 @@ with(require __DIR__.'/bootstrap/app.php', function ($app) {
 
 fwrite(STDERR, 'Attempting to decrypt environment variables into runtime'.PHP_EOL);
 
-Environment::decrypt();
+Environment::decrypt($app);
+
+/*
+|--------------------------------------------------------------------------
+| Cache Configuration
+|--------------------------------------------------------------------------
+|
+| To give the application a speed boost, we are going to cache all of the
+| configuration files into a single file. The file will be loaded once
+| by the runtime then it will read the configuration values from it.
+|
+*/
+
+StorageDirectories::create();
+
+$app->useStoragePath(StorageDirectories::PATH);
+
+fwrite(STDERR, 'Caching Laravel configuration'.PHP_EOL);
+
+$app->make(ConsoleKernelContract::class)->call('config:cache');
 
 /*
 |--------------------------------------------------------------------------

--- a/stubs/octaneRuntime.php
+++ b/stubs/octaneRuntime.php
@@ -11,6 +11,8 @@ use Laravel\Vapor\Runtime\StorageDirectories;
 
 $app = require __DIR__.'/bootstrap/app.php';
 
+$console = $app->make(ConsoleKernelContract::class);
+
 /*
 |--------------------------------------------------------------------------
 | Inject SSM Secrets Into Environment
@@ -62,7 +64,24 @@ $app->useStoragePath(StorageDirectories::PATH);
 
 fwrite(STDERR, 'Caching Laravel configuration'.PHP_EOL);
 
-$app->make(ConsoleKernelContract::class)->call('config:cache');
+$console->call('config:cache');
+
+/*
+|--------------------------------------------------------------------------
+| Cache Routes
+|--------------------------------------------------------------------------
+|
+| To further boost performance, we will attempt to cache the routes of the
+| application. Doing so will drastically decrease the amount of time it
+| takes to register all of the routes when firing up the application.
+|
+*/
+
+if (in_array('route:cache', array_keys($console->all()))) {
+    fwrite(STDERR, 'Caching Laravel routes'.PHP_EOL);
+
+    $console->call('route:cache');
+}
 
 /*
 |--------------------------------------------------------------------------

--- a/stubs/octaneRuntime.php
+++ b/stubs/octaneRuntime.php
@@ -77,7 +77,11 @@ $console->call('config:cache');
 |
 */
 
-if (version_compare($app->version(), '8.0', '>=')) {
+if (
+    version_compare($app->version(), '8.0', '>=')
+        && isset($_ENV['VAPOR_CACHE_ROUTES'])
+        && $_ENV['VAPOR_CACHE_ROUTES'] === 'true'
+) {
     fwrite(STDERR, 'Caching Laravel routes'.PHP_EOL);
 
     $console->call('route:cache');

--- a/stubs/octaneRuntime.php
+++ b/stubs/octaneRuntime.php
@@ -77,7 +77,7 @@ $console->call('config:cache');
 |
 */
 
-if (in_array('route:cache', array_keys($console->all()))) {
+if (version_compare($app->version(), '8.0', '>=')) {
     fwrite(STDERR, 'Caching Laravel routes'.PHP_EOL);
 
     $console->call('route:cache');

--- a/stubs/octaneRuntime.php
+++ b/stubs/octaneRuntime.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
+use Laravel\Vapor\Runtime\Environment;
 use Laravel\Vapor\Runtime\LambdaContainer;
 use Laravel\Vapor\Runtime\LambdaRuntime;
 use Laravel\Vapor\Runtime\Octane\Octane;
@@ -47,6 +48,21 @@ with(require __DIR__.'/bootstrap/app.php', function ($app) {
 
     $app->make(ConsoleKernelContract::class)->call('config:cache');
 });
+
+/*
+|--------------------------------------------------------------------------
+| Inject decrypted environment variables
+|--------------------------------------------------------------------------
+|
+| Next, we will check to see whether a decryption key has been set on the
+| environment. If so, we will attempt to discover an encrypted file at
+| the root of the application and decrypt it into the Vapor runtime.
+|
+*/
+
+fwrite(STDERR, 'Attempting to decrypt environment variables into runtime'.PHP_EOL);
+
+Environment::decrypt();
 
 /*
 |--------------------------------------------------------------------------

--- a/stubs/octaneRuntime.php
+++ b/stubs/octaneRuntime.php
@@ -9,6 +9,8 @@ use Laravel\Vapor\Runtime\Octane\OctaneHttpHandlerFactory;
 use Laravel\Vapor\Runtime\Secrets;
 use Laravel\Vapor\Runtime\StorageDirectories;
 
+$app = require __DIR__.'/bootstrap/app.php';
+
 /*
 |--------------------------------------------------------------------------
 | Inject SSM Secrets Into Environment
@@ -30,27 +32,6 @@ $secrets = Secrets::addToEnvironment(
 
 /*
 |--------------------------------------------------------------------------
-| Cache Configuration
-|--------------------------------------------------------------------------
-|
-| To give the application a speed boost, we are going to cache all of the
-| configuration files into a single file. The file will be loaded once
-| by the runtime then it will read the configuration values from it.
-|
-*/
-
-with(require __DIR__.'/bootstrap/app.php', function ($app) {
-    StorageDirectories::create();
-
-    $app->useStoragePath(StorageDirectories::PATH);
-
-    fwrite(STDERR, 'Caching Laravel configuration'.PHP_EOL);
-
-    $app->make(ConsoleKernelContract::class)->call('config:cache');
-});
-
-/*
-|--------------------------------------------------------------------------
 | Inject decrypted environment variables
 |--------------------------------------------------------------------------
 |
@@ -62,7 +43,26 @@ with(require __DIR__.'/bootstrap/app.php', function ($app) {
 
 fwrite(STDERR, 'Attempting to decrypt environment variables into runtime'.PHP_EOL);
 
-Environment::decrypt();
+Environment::decrypt($app);
+
+/*
+|--------------------------------------------------------------------------
+| Cache Configuration
+|--------------------------------------------------------------------------
+|
+| To give the application a speed boost, we are going to cache all of the
+| configuration files into a single file. The file will be loaded once
+| by the runtime then it will read the configuration values from it.
+|
+*/
+
+StorageDirectories::create();
+
+$app->useStoragePath(StorageDirectories::PATH);
+
+fwrite(STDERR, 'Caching Laravel configuration'.PHP_EOL);
+
+$app->make(ConsoleKernelContract::class)->call('config:cache');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Feature/ApiGatewayOctaneHandlerTest.php
+++ b/tests/Feature/ApiGatewayOctaneHandlerTest.php
@@ -86,7 +86,7 @@ class ApiGatewayOctaneHandlerTest extends TestCase
 
         Route::get('/', function (Request $request) {
             return response()->file(__DIR__.'/../Fixtures/asset.js', [
-                'Content-Type' => 'text/javascript',
+                'Content-Type' => 'text/javascript; charset=UTF-8',
             ]);
         });
 
@@ -95,7 +95,7 @@ class ApiGatewayOctaneHandlerTest extends TestCase
             'path' => '/',
         ]);
 
-        static::assertEquals('text/javascript', $response->toApiGatewayFormat()['headers']['Content-Type']);
+        static::assertEquals('text/javascript; charset=UTF-8', $response->toApiGatewayFormat()['headers']['Content-Type']);
         static::assertEquals("console.log();\n", $response->toApiGatewayFormat()['body']);
     }
 

--- a/tests/Feature/LambdaProxyOctaneHandlerTest.php
+++ b/tests/Feature/LambdaProxyOctaneHandlerTest.php
@@ -96,7 +96,7 @@ class LambdaProxyOctaneHandlerTest extends TestCase
 
         Route::get('/', function (Request $request) {
             return response()->file(__DIR__.'/../Fixtures/asset.js', [
-                'Content-Type' => 'text/javascript',
+                'Content-Type' => 'text/javascript; charset=UTF-8',
             ]);
         });
 
@@ -110,7 +110,7 @@ class LambdaProxyOctaneHandlerTest extends TestCase
             ],
         ]);
 
-        static::assertEquals('text/javascript', $response->toApiGatewayFormat()['headers']['Content-Type']);
+        static::assertEquals('text/javascript; charset=UTF-8', $response->toApiGatewayFormat()['headers']['Content-Type']);
         static::assertEquals("console.log();\n", $response->toApiGatewayFormat()['body']);
     }
 

--- a/tests/Feature/LoadBalancedOctaneHandlerTest.php
+++ b/tests/Feature/LoadBalancedOctaneHandlerTest.php
@@ -106,7 +106,7 @@ class LoadBalancedOctaneHandlerTest extends TestCase
 
         Route::get('/', function (Request $request) {
             return response()->file(__DIR__.'/../Fixtures/asset.js', [
-                'Content-Type' => 'text/javascript',
+                'Content-Type' => 'text/javascript; charset=UTF-8',
             ]);
         });
 
@@ -115,7 +115,7 @@ class LoadBalancedOctaneHandlerTest extends TestCase
             'path' => '/',
         ]);
 
-        static::assertEquals(['text/javascript'], $response->toApiGatewayFormat()['multiValueHeaders']['Content-Type']);
+        static::assertEquals(['text/javascript; charset=UTF-8'], $response->toApiGatewayFormat()['multiValueHeaders']['Content-Type']);
         static::assertEquals("console.log();\n", $response->toApiGatewayFormat()['body']);
     }
 


### PR DESCRIPTION
This PR adds support for automatic route caching.

I have branched from https://github.com/laravel/vapor-core/pull/140 as a lot of the refactoring carried out in there is relevant here.

A new environment variable - `APP_ROUTES_CACHE` - will need to be injected into the environment to ensure the route cache is written to the correct location. We'll also need to add `VAPOR_CACHE_ROUTES` to new environments. Those with existing environments can opt-in by manually setting this variable.

I've only added support of Laravel versions >= 8.0 as prior to this, `route:cache` would only work on controller based routes.

_____

### Tests

I registered 1,000 routes and ran the following command which hits the welcome route of a default Laravel application sending a single request one after another for a duration of 20 seconds.

```shell
wrk -t1 -c1 -d20 https://twilight-abyss-4jp7cxqapxbp.vapor-farm-f1.com
```

Here were the results based on ten requests logged in CloudWatch:

|                      | Cached | Uncached |
|----------------------|--------:|----------:|
| **Mean Response Time** | **8.313ms**     | **20.359ms**       |
| **Median Response Time**    | **7.825ms**     | **18.68ms**       |
| **Memory**    | **187MB**     | **165MB**       |

Increasing the number of requests with the command below yielded similar results. This runs five threads, each with five connections for a duration of 30 seconds.

```shell
wrk -t5 -c5 -d30 https://twilight-abyss-4jp7cxqapxbp.vapor-farm-f1.com
```

|                      | Cached | Uncached |
|----------------------|--------:|----------:|
| **Mean Response Time** | **7.203ms**     | **19.23ms**       |
| **Median Response Time**    | **7.185ms**     | **18.535ms**       |

**As you can see, caching the routes of an application with a large number of registered routes results in us speeding up response times dramatically. We have greater than halved the response time.**

**Unfortunately, we also see a significant increase in the memory consumption.**

_____

I ran a further couple of tests using the same commands, this time, hitting a database to return a single user record from an API endpoint:

**Single Request**
|                      | Cached | Uncached |
|----------------------|--------:|----------:|
| **Mean Response Time** | **91.56ms**     | **99.853ms**       |
| **Median Response Time**    | **90.625ms**     | **98.095ms**       |

**Multiple Requests**
|                      | Cached | Uncached |
|----------------------|--------:|----------:|
| **Mean Response Time** | **79.527ms**     | **99.048ms**       |
| **Median Response Time**    | **78.125ms**     | **99.73ms**       |
