### PR TITLE
[2.x] Removes non needed messages

### DIFF
--- a/src/Runtime/Environment.php
+++ b/src/Runtime/Environment.php
@@ -112,8 +112,6 @@ class Environment
     public function canBeDecrypted()
     {
         if (! isset($_ENV['LARAVEL_ENV_ENCRYPTION_KEY'])) {
-            fwrite(STDERR, 'No decryption key set.'.PHP_EOL);
-
             return false;
         }
 

--- a/stubs/cliRuntime.php
+++ b/stubs/cliRuntime.php
@@ -38,8 +38,6 @@ Secrets::addToEnvironment(
 |
 */
 
-fwrite(STDERR, 'Attempting to decrypt environment variables into runtime'.PHP_EOL);
-
 Environment::decrypt($app);
 
 /*

--- a/stubs/fpmRuntime.php
+++ b/stubs/fpmRuntime.php
@@ -41,8 +41,6 @@ $secrets = Secrets::addToEnvironment(
 |
 */
 
-fwrite(STDERR, 'Attempting to decrypt environment variables into runtime'.PHP_EOL);
-
 Environment::decrypt($app);
 
 /*

--- a/stubs/octaneRuntime.php
+++ b/stubs/octaneRuntime.php
@@ -41,8 +41,6 @@ $secrets = Secrets::addToEnvironment(
 |
 */
 
-fwrite(STDERR, 'Attempting to decrypt environment variables into runtime'.PHP_EOL);
-
 Environment::decrypt($app);
 
 /*


### PR DESCRIPTION
On support we've received questions about what are those messages - as they are generating hundreds of messages in our customers logs. Their are not necessary, as there is no errors at all if we don't have an `LARAVEL_ENV_ENCRYPTION_KEY` environment variable.