### PR TITLE
[2.x] Overrides existing variables when loading encrypted environment files

### DIFF
--- a/src/Runtime/Environment.php
+++ b/src/Runtime/Environment.php
@@ -158,7 +158,7 @@ class Environment
     {
         fwrite(STDERR, 'Loading decrypted environment variables.'.PHP_EOL);
 
-        Dotenv::createImmutable($this->writePath, $this->environmentFile)->load();
+        Dotenv::createMutable($this->writePath, $this->environmentFile)->load();
     }
 
     /**

--- a/stubs/fpmRuntime.php
+++ b/stubs/fpmRuntime.php
@@ -24,7 +24,7 @@ $app = require __DIR__.'/bootstrap/app.php';
 
 fwrite(STDERR, 'Preparing to add secrets to runtime'.PHP_EOL);
 
-$secrets = Secrets::addToEnvironment(
+Secrets::addToEnvironment(
     $_ENV['VAPOR_SSM_PATH'],
     json_decode($_ENV['VAPOR_SSM_VARIABLES'] ?? '[]', true),
     __DIR__.'/vaporSecrets.php'
@@ -76,7 +76,7 @@ $app->make(ConsoleKernelContract::class)->call('config:cache');
 fwrite(STDERR, 'Preparing to boot FPM'.PHP_EOL);
 
 $fpm = Fpm::boot(
-    __DIR__.'/httpHandler.php', $secrets
+    __DIR__.'/httpHandler.php'
 );
 
 /*

--- a/stubs/octaneRuntime.php
+++ b/stubs/octaneRuntime.php
@@ -24,7 +24,7 @@ $app = require __DIR__.'/bootstrap/app.php';
 
 fwrite(STDERR, 'Preparing to add secrets to runtime'.PHP_EOL);
 
-$secrets = Secrets::addToEnvironment(
+Secrets::addToEnvironment(
     $_ENV['VAPOR_SSM_PATH'],
     json_decode($_ENV['VAPOR_SSM_VARIABLES'] ?? '[]', true),
     __DIR__.'/vaporSecrets.php'


### PR DESCRIPTION
Currently when loading encrypted environment variables, existing variables which have already been added will not be overriden.

This causes an issue if, for instance, you wish to update the `SESSION_DRIVER`. At the moment, you could only do so by updating the environment in the Vapor UI or by adding a secret and **NOT** using an encrypted environment file.

By making the change from `Dotenv::createImmutable` to `Dotenv::createMutable`, existing variables will be overwritten.

After this PR, the priority order for loading environment variables is as below with each having priority over the previous.

- Injected by Vapor
- Added to the Vapor UI
- Secrets
- Encrypted environment files
