### PR TITLE
[2.x] Ignores invalid cookies

### DIFF
--- a/src/Runtime/Octane/OctaneRequestContextFactory.php
+++ b/src/Runtime/Octane/OctaneRequestContextFactory.php
@@ -72,10 +72,16 @@ class OctaneRequestContextFactory
         }
 
         return Collection::make(explode('; ', $headers['cookie']))->mapWithKeys(function ($cookie) {
-            [$key, $value] = explode('=', trim($cookie), 2);
+            $cookie = explode('=', trim($cookie), 2);
 
-            return [$key => urldecode($value)];
-        })->all();
+            $key = $cookie[0];
+
+            if (! isset($cookie[1])) {
+                return [$key => null];
+            }
+
+            return [$key => urldecode($cookie[1])];
+        })->filter()->all();
     }
 
     /**

--- a/tests/Feature/ApiGatewayOctaneHandlerTest.php
+++ b/tests/Feature/ApiGatewayOctaneHandlerTest.php
@@ -333,6 +333,28 @@ EOF
         );
     }
 
+    public function test_request_ignores_invalid_cookies()
+    {
+        $handler = new OctaneHandler();
+
+        Route::get('/', function (Request $request) {
+            return $request->cookies->all();
+        });
+
+        $response = $handler->handle([
+            'httpMethod' => 'GET',
+            'path' => '/',
+            'headers' => [
+                'cookie' => 'cookieKey1; cookieKey2=cookieValue2',
+            ],
+        ]);
+
+        static::assertEquals(
+            ['cookieKey2' => 'cookieValue2'],
+            json_decode($response->toApiGatewayFormat()['body'], true)
+        );
+    }
+
     public function test_request_file_uploads()
     {
         $handler = new OctaneHandler();

--- a/tests/Feature/LambdaProxyOctaneHandlerTest.php
+++ b/tests/Feature/LambdaProxyOctaneHandlerTest.php
@@ -407,6 +407,33 @@ EOF
         );
     }
 
+    public function test_request_ignores_invalid_cookies()
+    {
+        $handler = new OctaneHandler();
+
+        Route::get('/', function (Request $request) {
+            return $request->cookies->all();
+        });
+
+        $response = $handler->handle([
+            'version' => '2.0',
+            'requestContext' => [
+                'http' => [
+                    'method' => 'GET',
+                    'path' => '/',
+                ],
+            ],
+            'headers' => [
+                'cookie' => 'cookieKey1; cookieKey2=cookieValue2',
+            ],
+        ]);
+
+        static::assertEquals(
+            ['cookieKey2' => 'cookieValue2'],
+            json_decode($response->toApiGatewayFormat()['body'], true)
+        );
+    }
+
     public function test_request_file_uploads()
     {
         $handler = new OctaneHandler();

--- a/tests/Feature/LoadBalancedOctaneHandlerTest.php
+++ b/tests/Feature/LoadBalancedOctaneHandlerTest.php
@@ -424,6 +424,28 @@ EOF
         );
     }
 
+    public function test_request_ignores_invalid_cookies()
+    {
+        $handler = new LoadBalancedOctaneHandler();
+
+        Route::get('/', function (Request $request) {
+            return $request->cookies->all();
+        });
+
+        $response = $handler->handle([
+            'httpMethod' => 'GET',
+            'path' => '/',
+            'headers' => [
+                'cookie' => 'cookieKey1; cookieKey2=cookieValue2',
+            ],
+        ]);
+
+        static::assertEquals(
+            ['cookieKey2' => 'cookieValue2'],
+            json_decode($response->toApiGatewayFormat()['body'], true)
+        );
+    }
+
     public function test_request_query_string()
     {
         $handler = new LoadBalancedOctaneHandler();


### PR DESCRIPTION
This pull request causes Octane's request factory in Vapor Core to ignore invalid cookies, specifically cookies that only have a key and no value.

We do not know the reasons why a cookie would only have a key, but a particular customer has reported facing this issue:

```
Fatal error: Uncaught ErrorException: Undefined array key 1 in /var/task/vendor/laravel/vapor-core/src/Runtime/Octane/OctaneRequestContextFactory.php:75 
```