### PR TITLE
[2.x] Adds health check command

### DIFF
--- a/src/Console/Commands/VaporHealthCheckCommand.php
+++ b/src/Console/Commands/VaporHealthCheckCommand.php
@@ -25,7 +25,7 @@ class VaporHealthCheckCommand extends Command
      *
      * @var bool
      */
-    protected $hidden = false;
+    protected $hidden = true;
 
     /**
      * Execute the console command.

--- a/src/Console/Commands/VaporHealthCheckCommand.php
+++ b/src/Console/Commands/VaporHealthCheckCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Laravel\Vapor\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class VaporHealthCheckCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'vapor:health-check';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Check the health of the Vapor application';
+
+    /**
+     * Indicates whether the command should be shown in the Artisan command list.
+     *
+     * @var bool
+     */
+    protected $hidden = false;
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        return $this->info('Health check complete!');
+    }
+}

--- a/src/VaporServiceProvider.php
+++ b/src/VaporServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
 use Laravel\Vapor\Console\Commands\OctaneStatusCommand;
+use Laravel\Vapor\Console\Commands\VaporHealthCheckCommand;
 use Laravel\Vapor\Console\Commands\VaporQueueListFailedCommand;
 use Laravel\Vapor\Console\Commands\VaporWorkCommand;
 use Laravel\Vapor\Http\Controllers\SignedStorageUrlController;
@@ -168,7 +169,11 @@ class VaporServiceProvider extends ServiceProvider
             return new VaporQueueListFailedCommand;
         });
 
-        $this->commands(['command.vapor.work', 'command.vapor.queue-failed']);
+        $this->app->singleton('command.vapor.health-check', function () {
+            return new VaporHealthCheckCommand;
+        });
+
+        $this->commands(['command.vapor.work', 'command.vapor.queue-failed', 'command.vapor.health-check']);
     }
 
     /**

--- a/tests/Feature/ApiGatewayOctaneHandlerTest.php
+++ b/tests/Feature/ApiGatewayOctaneHandlerTest.php
@@ -390,7 +390,6 @@ Content-Disposition: form-data; name="file"; filename="my_uploaded.txt"
 Content-Type: text/plain
 
 foo
-
 -----------------------------317050813134112680482597024243--
 EOF
         ]);
@@ -435,7 +434,6 @@ Content-Disposition: form-data; name="file"; filename="my_uploaded.txt"
 Content-Type: text/plain
 
 foo
-
 -----------------------------317050813134112680482597024243--
 EOF
         ]);

--- a/tests/Feature/LambdaProxyOctaneHandlerTest.php
+++ b/tests/Feature/LambdaProxyOctaneHandlerTest.php
@@ -474,7 +474,6 @@ Content-Disposition: form-data; name="file"; filename="my_uploaded.txt"
 Content-Type: text/plain
 
 foo
-
 -----------------------------317050813134112680482597024243--
 EOF
         ]);
@@ -524,7 +523,6 @@ Content-Disposition: form-data; name="file"; filename="my_uploaded.txt"
 Content-Type: text/plain
 
 foo
-
 -----------------------------317050813134112680482597024243--
 EOF
         ]);

--- a/tests/Feature/LoadBalancedOctaneHandlerTest.php
+++ b/tests/Feature/LoadBalancedOctaneHandlerTest.php
@@ -344,7 +344,6 @@ Content-Disposition: form-data; name="file"; filename="my_uploaded.txt"
 Content-Type: text/plain
 
 foo
-
 -----------------------------317050813134112680482597024243--
 EOF
         ]);
@@ -389,7 +388,6 @@ Content-Disposition: form-data; name="file"; filename="my_uploaded.txt"
 Content-Type: text/plain
 
 foo
-
 -----------------------------317050813134112680482597024243--
 EOF
         ]);


### PR DESCRIPTION
This PR adds a new hidden command to the Vapor Core which will be used during deployment to determine whether or not an environment being deployed is healthy or not.

Updates to the tests are due to an change to [laminas-diactoros](https://github.com/laminas/laminas-diactoros/compare/2.25.1...2.25.2)