### PR TITLE
[2.x] Prevents FPM from crashing when body is sent with a GET request

### DIFF
--- a/src/Runtime/Handlers/FpmHandler.php
+++ b/src/Runtime/Handlers/FpmHandler.php
@@ -15,16 +15,9 @@ class FpmHandler implements LambdaEventHandler
      * @return \Laravel\Vapor\Contracts\LambdaResponse
      */
     public function handle(array $event)
-    {
-        $request = $this->request($event);
-        $method = isset($request->serverVariables['REQUEST_METHOD']) ? $request->serverVariables['REQUEST_METHOD'] : null;
-
-        if ($request->body !== '' && $method === 'GET') {
-            return new LambdaResponse(403, [], '');
-        }
-
+    {   
         return $this->response(
-            Fpm::resolve()->handle($request)
+            Fpm::resolve()->handle($this->request($event))
         );
     }
 
@@ -36,6 +29,8 @@ class FpmHandler implements LambdaEventHandler
      */
     public function request($event)
     {
+        info('Event', $event);
+        
         return FpmRequest::fromLambdaEvent(
             $event, $this->serverVariables(), Fpm::resolve()->handler()
         );

--- a/src/Runtime/Handlers/FpmHandler.php
+++ b/src/Runtime/Handlers/FpmHandler.php
@@ -19,7 +19,7 @@ class FpmHandler implements LambdaEventHandler
         $request = $this->request($event);
         $method = isset($request->serverVariables['REQUEST_METHOD']) ? $request->serverVariables['REQUEST_METHOD'] : null;
 
-        if ($request->body && $method === 'GET') {
+        if ($request->body !== '' && $method === 'GET') {
             return new LambdaResponse(403, [], '');
         }
 

--- a/src/Runtime/Handlers/FpmHandler.php
+++ b/src/Runtime/Handlers/FpmHandler.php
@@ -17,8 +17,9 @@ class FpmHandler implements LambdaEventHandler
     public function handle(array $event)
     {
         $request = $this->request($event);
+        $method = isset($request->serverVariables['REQUEST_METHOD']) ? $request->serverVariables['REQUEST_METHOD'] : null;
 
-        if ($request->body && ($request->serverVariables['REQUEST_METHOD'] ?? null) === 'GET') {
+        if ($request->body && $method === 'GET') {
             return new LambdaResponse(403, [], '');
         }
 

--- a/src/Runtime/Handlers/FpmHandler.php
+++ b/src/Runtime/Handlers/FpmHandler.php
@@ -28,7 +28,7 @@ class FpmHandler implements LambdaEventHandler
      * @return \Laravel\Vapor\Runtime\Fpm\FpmRequest
      */
     public function request($event)
-    {        
+    {
         return FpmRequest::fromLambdaEvent(
             $event, $this->serverVariables(), Fpm::resolve()->handler()
         );

--- a/src/Runtime/Handlers/FpmHandler.php
+++ b/src/Runtime/Handlers/FpmHandler.php
@@ -12,13 +12,18 @@ class FpmHandler implements LambdaEventHandler
     /**
      * Handle an incoming Lambda event.
      *
-     * @param  array  $event
      * @return \Laravel\Vapor\Contracts\LambdaResponse
      */
     public function handle(array $event)
     {
+        $request = $this->request($event);
+
+        if ($request->body && ($request->serverVariables['REQUEST_METHOD'] ?? null) === 'GET') {
+            return new LambdaResponse(403, [], '');
+        }
+
         return $this->response(
-            Fpm::resolve()->handle($this->request($event))
+            Fpm::resolve()->handle($request)
         );
     }
 

--- a/src/Runtime/Handlers/FpmHandler.php
+++ b/src/Runtime/Handlers/FpmHandler.php
@@ -15,7 +15,7 @@ class FpmHandler implements LambdaEventHandler
      * @return \Laravel\Vapor\Contracts\LambdaResponse
      */
     public function handle(array $event)
-    {   
+    {
         return $this->response(
             Fpm::resolve()->handle($this->request($event))
         );
@@ -28,9 +28,7 @@ class FpmHandler implements LambdaEventHandler
      * @return \Laravel\Vapor\Runtime\Fpm\FpmRequest
      */
     public function request($event)
-    {
-        info('Event', $event);
-        
+    {        
         return FpmRequest::fromLambdaEvent(
             $event, $this->serverVariables(), Fpm::resolve()->handler()
         );

--- a/stubs/fpmRuntime.php
+++ b/stubs/fpmRuntime.php
@@ -107,7 +107,7 @@ while (true) {
             if (Str::contains($e->getMessage(), 'Failed to write request to socket [broken pipe]')) {
                 function_exists('__vapor_debug') && __vapor_debug($e->getMessage());
 
-                return (new LambdaResponse(500, [], ''))
+                return (new LambdaResponse(403, [], ''))
                     ->toApiGatewayFormat();
             }
 

--- a/stubs/fpmRuntime.php
+++ b/stubs/fpmRuntime.php
@@ -104,8 +104,7 @@ while (true) {
                 ->handle($event)
                 ->toApiGatewayFormat();
         } catch (WriteFailedException $e) {
-            $method = $event['httpMethod'] ?? $event['requestContext']['http']['method'] ?? null;
-            if (Str::contains($e->getMessage(), 'Failed to write request to socket [broken pipe]') && $method === 'GET' && $event['body'] !== null) {
+            if (Str::contains($e->getMessage(), 'Failed to write request to socket [broken pipe]')) {
                 function_exists('__vapor_debug') && __vapor_debug($e->getMessage());
 
                 return (new LambdaResponse(403, [], ''))

--- a/stubs/fpmRuntime.php
+++ b/stubs/fpmRuntime.php
@@ -1,10 +1,13 @@
 <?php
 
+use hollodotme\FastCGI\Exceptions\WriteFailedException;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
+use Illuminate\Support\Str;
 use Laravel\Vapor\Runtime\Environment;
 use Laravel\Vapor\Runtime\Fpm\Fpm;
 use Laravel\Vapor\Runtime\Fpm\FpmHttpHandlerFactory;
 use Laravel\Vapor\Runtime\LambdaContainer;
+use Laravel\Vapor\Runtime\LambdaResponse;
 use Laravel\Vapor\Runtime\LambdaRuntime;
 use Laravel\Vapor\Runtime\Secrets;
 use Laravel\Vapor\Runtime\StorageDirectories;
@@ -96,9 +99,20 @@ $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
 
 while (true) {
     $lambdaRuntime->nextInvocation(function ($invocationId, $event) {
-        return FpmHttpHandlerFactory::make($event)
-            ->handle($event)
-            ->toApiGatewayFormat();
+        try {
+            return FpmHttpHandlerFactory::make($event)
+                ->handle($event)
+                ->toApiGatewayFormat();
+        } catch (WriteFailedException $e) {
+            if (Str::contains($e->getMessage(), 'Failed to write request to socket [broken pipe]')) {
+                function_exists('__vapor_debug') && __vapor_debug($e->getMessage());
+
+                return (new LambdaResponse(500, [], ''))
+                    ->toApiGatewayFormat();
+            }
+
+            throw $e;
+        }
     });
 
     $fpm->ensureRunning();

--- a/stubs/fpmRuntime.php
+++ b/stubs/fpmRuntime.php
@@ -104,7 +104,8 @@ while (true) {
                 ->handle($event)
                 ->toApiGatewayFormat();
         } catch (WriteFailedException $e) {
-            if (Str::contains($e->getMessage(), 'Failed to write request to socket [broken pipe]')) {
+            $method = $event['httpMethod'] ?? $event['requestContext']['http']['method'] ?? null;
+            if (Str::contains($e->getMessage(), 'Failed to write request to socket [broken pipe]') && $method === 'GET' && $event['body'] !== null) {
                 function_exists('__vapor_debug') && __vapor_debug($e->getMessage());
 
                 return (new LambdaResponse(403, [], ''))


### PR DESCRIPTION
This issue specifically occurs when resolving an instance of [ServerRequestInterface](https://laravel.com/docs/10.x/requests#psr7-requests) from the container.

In this scenario, every other request fails and causes FPM to restart.

The Sentry SDK relies on resolving this from the container, so this issue may be more common than it may seem at first glance.