### PR TITLE
Abstract the key to easier override

### DIFF
--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -34,7 +34,7 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
         $expiresAfter = config('vapor.signed_storage_url_expires_after', 5);
 
         $signedRequest = $client->createPresignedRequest(
-            $this->createCommand($request, $client, $bucket, $key = ('tmp/'.$uuid)),
+            $this->createCommand($request, $client, $bucket, $key = $this->getKey($uuid)),
             sprintf('+%s minutes', $expiresAfter)
         );
 
@@ -47,6 +47,17 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
             'url' => $uri->getScheme().'://'.$uri->getAuthority().$uri->getPath().'?'.$uri->getQuery(),
             'headers' => $this->headers($request, $signedRequest),
         ], 201);
+    }
+
+    /**
+     * Get key for the given UUID.
+     *
+     * @param string $uuid
+     * @return string
+     */
+    protected function getKey(string $uuid)
+    {
+        return 'tmp/'.$uuid;
     }
 
     /**

--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -50,17 +50,6 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
     }
 
     /**
-     * Get key for the given UUID.
-     *
-     * @param string $uuid
-     * @return string
-     */
-    protected function getKey(string $uuid)
-    {
-        return 'tmp/'.$uuid;
-    }
-
-    /**
      * Create a command for the PUT operation.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -150,6 +139,17 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
         }
 
         return new S3Client($config);
+    }
+
+    /**
+     * Get key for the given UUID.
+     *
+     * @param  string  $uuid
+     * @return string
+     */
+    protected function getKey(string $uuid)
+    {
+        return 'tmp/'.$uuid;
     }
 
     /**


### PR DESCRIPTION
Spoke with Joe about this idea via email.

We need the ability to change the key in our app because we use a root prefix in `config/filesystems.php` and use the same bucket across multiple staging environments.

Per the discussion we would need to override the controller and customize it ourselves.

It would be helpful if the key was abstracted so we didn't have to duplicate the entire logic in `store`