### PR TITLE
[2.0] Fixes streamed responses when using Octane

### DIFF
--- a/tests/Feature/ApiGatewayOctaneHandlerTest.php
+++ b/tests/Feature/ApiGatewayOctaneHandlerTest.php
@@ -17,6 +17,7 @@ use Laravel\Vapor\Runtime\Octane\Octane;
 use Laravel\Vapor\Tests\TestCase;
 use Mockery;
 use RuntimeException;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ApiGatewayOctaneHandlerTest extends TestCase
 {
@@ -600,5 +601,25 @@ EOF
 
         static::assertEquals('application/json', $response->toApiGatewayFormat()['headers']['Content-Type']);
         static::assertEquals(['message' => 'We are currently down for maintenance.'], json_decode($response->toApiGatewayFormat()['body'], true));
+    }
+
+    public function test_streamed_responses()
+    {
+        $handler = new OctaneHandler();
+
+        Route::get('/', function () {
+            return new StreamedResponse(function () {
+                echo 'Hello World';
+            }, 200, ['mime-type' => 'image/png']);
+        });
+
+        $response = $handler->handle([
+            'httpMethod' => 'GET',
+            'path' => '/',
+            'headers' => [],
+        ]);
+
+        static::assertEquals('image/png', $response->toApiGatewayFormat()['headers']['Mime-Type']);
+        static::assertEquals('Hello World', $response->toApiGatewayFormat()['body']);
     }
 }

--- a/tests/Feature/LoadBalancedOctaneHandlerTest.php
+++ b/tests/Feature/LoadBalancedOctaneHandlerTest.php
@@ -17,6 +17,7 @@ use Laravel\Vapor\Runtime\Octane\Octane;
 use Laravel\Vapor\Tests\TestCase;
 use Mockery;
 use RuntimeException;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class LoadBalancedOctaneHandlerTest extends TestCase
 {
@@ -598,5 +599,27 @@ EOF
 
         static::assertEquals(['application/json'], $response->toApiGatewayFormat()['multiValueHeaders']['Content-Type']);
         static::assertEquals(['message' => 'We are currently down for maintenance.'], json_decode($response->toApiGatewayFormat()['body'], true));
+    }
+
+    public function test_streamed_responses()
+    {
+        $handler = new LoadBalancedOctaneHandler();
+
+        Route::get('/', function () {
+            return new StreamedResponse(function () {
+                echo 'Hello World';
+            }, 200, ['mime-type' => 'image/png']);
+        });
+
+        $response = $handler->handle([
+            'httpMethod' => 'GET',
+            'path' => '/',
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+        ]);
+
+        static::assertEquals(['image/png'], $response->toApiGatewayFormat()['multiValueHeaders']['Mime-Type']);
+        static::assertEquals('Hello World', $response->toApiGatewayFormat()['body']);
     }
 }


### PR DESCRIPTION
When using Octane of Vapor and returning a `StreamedResponse` such as `Storage::download('my-file.png');`, the file is downloaded with no content.

The following code is the issue:

```php
$content = $response instanceof BinaryFileResponse
            ? $response->getFile()->getContent()
            : $response->getContent();
```

Calling `getContent()` on a `StreamedResponse` returns `false` and so we end up with a file with no content.

With Lambda, we can't stream directly to the client. Instead, this PR captures the content from the stream and returns it. 