### PR TITLE
[2.x] Adds support for guzzlehttp/promises 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "aws/aws-sdk-php": "^3.80",
-        "psr/http-message": "^1.0",
-        "guzzlehttp/promises": "^1.4.0",
+        "guzzlehttp/promises": "^1.4|^2.0",
         "guzzlehttp/guzzle": "^6.3|^7.0",
         "hollodotme/fast-cgi-client": "^3.0",
         "illuminate/container": "^6.0|^7.0|^8.0|^9.0|^10.0",


### PR DESCRIPTION
We previously had to lock `guzzlehttp/promises` at `^1.4.0` because an upstream dependency started to allow `^1.4.0||^2.0`.

We were using the `Promise\settle()` function which was deprecated and removed in `2.0`.

I refactored the code to use `Utils::settle()` which is supported in both 1.4 and 2.0 so I believe we're safe setting this to `^1.4.0||^2.0` to ensure it doesn't break for anyone relying on `1.4`.

I also removed `psr/http-message` as I can't find it used anywhere in the package. 