### PR TITLE
[2.x] Adds helpers to determine when an app is running on Vapor 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,10 @@
         "laravel": {
             "providers": [
                 "Laravel\\Vapor\\VaporServiceProvider"
-            ]
+            ],
+            "aliases": {
+                "Vapor": "Laravel\\Vapor\\Vapor"
+            }
         }
     },
     "config": {

--- a/src/Vapor.php
+++ b/src/Vapor.php
@@ -22,6 +22,10 @@ class Vapor
 
     /**
      * Apply the callback if the environment is Vapor.
+     *
+     * @param  mixed  $whenActive
+     * @param  mixed  $whenInactive
+     * @return mixed
      */
     public static function whenActive($whenActive, $whenInactive = null)
     {
@@ -34,6 +38,10 @@ class Vapor
 
     /**
      * Apply the callback if the environment is not Vapor.
+     *
+     * @param  mixed  $whenInactive
+     * @param  mixed  $whenActive
+     * @return mixed
      */
     public static function whenInactive($whenInactive, $whenActive = null)
     {

--- a/src/Vapor.php
+++ b/src/Vapor.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Laravel\Vapor;
+
+class Vapor
+{
+    /**
+     * Determine whether the environment is Vapor.
+     */
+    public static function active(): bool
+    {
+        return env('VAPOR_SSM_PATH') !== null;
+    }
+
+    /**
+     * Determine whether the environment is not Vapor.
+     */
+    public static function inactive(): bool
+    {
+        return ! static::active();
+    }
+
+    /**
+     * Apply the callback if the environment is Vapor.
+     */
+    public static function whenActive(mixed $whenActive, mixed $whenInactive = null): mixed
+    {
+        if (static::active()) {
+            return value($whenActive);
+        }
+
+        return value($whenInactive);
+    }
+
+    /**
+     * Apply the callback if the environment is not Vapor.
+     */
+    public static function whenInactive(mixed $whenInactive, mixed $whenActive = null): mixed
+    {
+        return static::whenActive($whenActive, $whenInactive);
+    }
+}

--- a/src/Vapor.php
+++ b/src/Vapor.php
@@ -23,7 +23,7 @@ class Vapor
     /**
      * Apply the callback if the environment is Vapor.
      */
-    public static function whenActive(mixed $whenActive, mixed $whenInactive = null): mixed
+    public static function whenActive($whenActive, $whenInactive = null)
     {
         if (static::active()) {
             return value($whenActive);
@@ -35,7 +35,7 @@ class Vapor
     /**
      * Apply the callback if the environment is not Vapor.
      */
-    public static function whenInactive(mixed $whenInactive, mixed $whenActive = null): mixed
+    public static function whenInactive($whenInactive, $whenActive = null)
     {
         return static::whenActive($whenActive, $whenInactive);
     }

--- a/src/Vapor.php
+++ b/src/Vapor.php
@@ -21,7 +21,7 @@ class Vapor
     }
 
     /**
-     * Apply the callback if the environment is Vapor.
+     * Execute the callback if the environment is Vapor.
      *
      * @param  mixed  $whenActive
      * @param  mixed  $whenInactive
@@ -37,7 +37,7 @@ class Vapor
     }
 
     /**
-     * Apply the callback if the environment is not Vapor.
+     * Execute the callback if the environment is not Vapor.
      *
      * @param  mixed  $whenInactive
      * @param  mixed  $whenActive

--- a/tests/Unit/VaporTest.php
+++ b/tests/Unit/VaporTest.php
@@ -37,7 +37,9 @@ class VaporTest extends TestCase
     {
         $_ENV['VAPOR_SSM_PATH'] = '/my-project-production';
 
-        $this->assertSame('active', Vapor::whenActive(function () { return 'active'; }, 'inactive'));
+        $this->assertSame('active', Vapor::whenActive(function () {
+            return 'active';
+        }, 'inactive'));
     }
 
     public function test_vapor_when_inactive()
@@ -47,6 +49,8 @@ class VaporTest extends TestCase
 
     public function test_vapor_when_inactive_with_callback()
     {
-        $this->assertSame('inactive', Vapor::whenInactive(function () { return 'inactive'; }, 'active'));
+        $this->assertSame('inactive', Vapor::whenInactive(function () {
+            return 'inactive';
+        }, 'active'));
     }
 }

--- a/tests/Unit/VaporTest.php
+++ b/tests/Unit/VaporTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Laravel\Vapor\Tests\Unit;
+
+use Laravel\Vapor\Vapor;
+use Orchestra\Testbench\TestCase;
+
+class VaporTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        unset($_ENV['VAPOR_SSM_PATH']);
+    }
+
+    public function test_vapor_active()
+    {
+        $_ENV['VAPOR_SSM_PATH'] = '/my-project-production';
+
+        $this->assertTrue(Vapor::active());
+    }
+
+    public function test_vapor_inactive()
+    {
+        $this->assertTrue(Vapor::inactive());
+    }
+
+    public function test_vapor_when_active()
+    {
+        $_ENV['VAPOR_SSM_PATH'] = '/my-project-production';
+
+        $this->assertSame('active', Vapor::whenActive('active', 'inactive'));
+    }
+
+    public function test_vapor_when_active_with_callback()
+    {
+        $_ENV['VAPOR_SSM_PATH'] = '/my-project-production';
+
+        $this->assertSame('active', Vapor::whenActive(fn () => 'active', 'inactive'));
+    }
+
+    public function test_vapor_when_inactive()
+    {
+        $this->assertSame('inactive', Vapor::whenInactive('inactive', 'active'));
+    }
+
+    public function test_vapor_when_inactive_with_callback()
+    {
+        $this->assertSame('inactive', Vapor::whenInactive(fn () => 'inactive', 'active'));
+    }
+}

--- a/tests/Unit/VaporTest.php
+++ b/tests/Unit/VaporTest.php
@@ -37,7 +37,7 @@ class VaporTest extends TestCase
     {
         $_ENV['VAPOR_SSM_PATH'] = '/my-project-production';
 
-        $this->assertSame('active', Vapor::whenActive(fn () => 'active', 'inactive'));
+        $this->assertSame('active', Vapor::whenActive(function () { return 'active'; }, 'inactive'));
     }
 
     public function test_vapor_when_inactive()
@@ -47,6 +47,6 @@ class VaporTest extends TestCase
 
     public function test_vapor_when_inactive_with_callback()
     {
-        $this->assertSame('inactive', Vapor::whenInactive(fn () => 'inactive', 'active'));
+        $this->assertSame('inactive', Vapor::whenInactive(function () { return 'inactive'; }, 'active'));
     }
 }


### PR DESCRIPTION
This PR introduces four new helper methods:

```php
Vapor::active(); // true on Vapor, false off Vapor
Vapor::inactive(); // false on Vapor, true off Vapor
Vapor::whenActive('active', 'inactive'); // 'active' on Vapor, 'inactive' off Vapor 
Vapor::whenInactive('inactive', 'active'); // 'active' on Vapor, 'inactive' off Vapor
Vapor::whenActive(fn () => 1 + 2); // 3 on Vapor, null off Vapor
```

Also added `Vapor` as an alias to composer.json to make it easy to use in blade views etc.

All this functionality revolves around the presence of the `VAPOR_SSM_PATH` variable.