### PR TITLE
[2.x] Adds scheduler proxy command to normalize sub-minute schedules

### DIFF
--- a/src/Console/Commands/VaporScheduleCommand.php
+++ b/src/Console/Commands/VaporScheduleCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Laravel\Vapor\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Str;
+
+class VaporScheduleCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'vapor:schedule';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run a more granular scheduler for Vapor';
+
+    /**
+     * Indicates whether the command should be shown in the Artisan command list.
+     *
+     * @var bool
+     */
+    protected $hidden = true;
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! $cache = $this->ensureValidCacheDriver()) {
+            $this->call('schedule:run');
+
+            return self::SUCCESS;
+        }
+
+        $key = (string) Str::uuid();
+        $lockObtained = false;
+
+        while (true) {
+            if (! $lockObtained) {
+                $lockObtained = $this->obtainLock($cache, $key);
+            }
+
+            if ($lockObtained && now()->second === 0) {
+                $this->call('schedule:run');
+
+                $this->releaseLock($cache);
+
+                return self::SUCCESS;
+            }
+
+            usleep(10000);
+        }
+    }
+
+    /**
+     * Ensure the cache driver is valid.
+     */
+    protected function ensureValidCacheDriver(): ?Repository
+    {
+        $manager = $this->laravel['cache'];
+
+        if (in_array($manager->getDefaultDriver(), ['memcached', 'redis', 'dynamodb', 'database'])) {
+            return $manager->driver();
+        }
+    }
+
+    /**
+     * Obtain the lock for the schedule.
+     */
+    protected function obtainLock(Repository $cache, string $key): bool
+    {
+        return $key === $cache->remember('vapor:schedule:lock', 60, fn () => $key);
+    }
+
+    /**
+     * Release the lock for the schedule.
+     *
+     * @param  string  $key
+     */
+    protected function releaseLock(Repository $cache): void
+    {
+        $cache->forget('vapor:schedule:lock');
+    }
+}

--- a/src/Console/Commands/VaporScheduleCommand.php
+++ b/src/Console/Commands/VaporScheduleCommand.php
@@ -79,7 +79,7 @@ class VaporScheduleCommand extends Command
      */
     protected function obtainLock(Repository $cache, string $key): bool
     {
-        return $key === $cache->remember('vapor:schedule:lock', 60, fn () => $key);
+        return $key === $cache->remember('vapor:schedule:lock', 60, function () use ($key) { return $key; });
     }
 
     /**

--- a/src/Console/Commands/VaporScheduleCommand.php
+++ b/src/Console/Commands/VaporScheduleCommand.php
@@ -72,6 +72,8 @@ class VaporScheduleCommand extends Command
         if (in_array($manager->getDefaultDriver(), ['memcached', 'redis', 'dynamodb', 'database'])) {
             return $manager->driver();
         }
+
+        return null;
     }
 
     /**

--- a/src/Console/Commands/VaporScheduleCommand.php
+++ b/src/Console/Commands/VaporScheduleCommand.php
@@ -20,7 +20,7 @@ class VaporScheduleCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Normalize the Vapor scheduler to run at the top of every minute';
+    protected $description = 'Run the scheduled commands at the beginning of every minute';
 
     /**
      * Indicates whether the command should be shown in the Artisan command list.

--- a/src/Console/Commands/VaporScheduleCommand.php
+++ b/src/Console/Commands/VaporScheduleCommand.php
@@ -81,7 +81,9 @@ class VaporScheduleCommand extends Command
      */
     protected function obtainLock(Repository $cache, string $key): bool
     {
-        return $key === $cache->remember('vapor:schedule:lock', 60, function () use ($key) { return $key; });
+        return $key === $cache->remember('vapor:schedule:lock', 60, function () use ($key) {
+            return $key;
+        });
     }
 
     /**

--- a/src/VaporServiceProvider.php
+++ b/src/VaporServiceProvider.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 use Laravel\Vapor\Console\Commands\OctaneStatusCommand;
 use Laravel\Vapor\Console\Commands\VaporHealthCheckCommand;
 use Laravel\Vapor\Console\Commands\VaporQueueListFailedCommand;
+use Laravel\Vapor\Console\Commands\VaporScheduleCommand;
 use Laravel\Vapor\Console\Commands\VaporWorkCommand;
 use Laravel\Vapor\Http\Controllers\SignedStorageUrlController;
 use Laravel\Vapor\Http\Middleware\ServeStaticAssets;
@@ -173,7 +174,11 @@ class VaporServiceProvider extends ServiceProvider
             return new VaporHealthCheckCommand;
         });
 
-        $this->commands(['command.vapor.work', 'command.vapor.queue-failed', 'command.vapor.health-check']);
+        $this->app->singleton('command.vapor.schedule', function () {
+            return new VaporScheduleCommand;
+        });
+
+        $this->commands(['command.vapor.work', 'command.vapor.queue-failed', 'command.vapor.health-check', 'command.vapor.schedule']);
     }
 
     /**

--- a/tests/Unit/VaporScheduleCommandTest.php
+++ b/tests/Unit/VaporScheduleCommandTest.php
@@ -4,7 +4,6 @@ namespace Laravel\Vapor\Tests\Unit;
 
 use Carbon\Carbon;
 use Illuminate\Cache\Repository;
-use Illuminate\Foundation\Testing\WithConsoleEvents;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Laravel\Vapor\VaporServiceProvider;
@@ -13,8 +12,6 @@ use Orchestra\Testbench\TestCase;
 
 class VaporScheduleCommandTest extends TestCase
 {
-    use WithConsoleEvents;
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Unit/VaporScheduleCommandTest.php
+++ b/tests/Unit/VaporScheduleCommandTest.php
@@ -35,7 +35,9 @@ class VaporScheduleCommandTest extends TestCase
         Cache::shouldReceive('getDefaultDriver')->once()->andReturn('array');
         Cache::shouldReceive('driver')->once()->andReturn($fake = Mockery::mock(Repository::class));
         $fake->shouldNotReceive('remember');
-        $fake->shouldReceive('forget')->once()->with('illuminate:schedule:interrupt')->andReturn(true);
+        if (version_compare($this->app->version(), 10, '>=')) {
+            $fake->shouldReceive('forget')->once()->with('illuminate:schedule:interrupt')->andReturn(true);
+        }
         $fake->shouldNotReceive('forget')->with('vapor:schedule:lock');
 
         $this->artisan('vapor:schedule')
@@ -47,7 +49,9 @@ class VaporScheduleCommandTest extends TestCase
         Cache::shouldReceive('getDefaultDriver')->once()->andReturn('dynamodb');
         Cache::shouldReceive('driver')->twice()->andReturn($fake = Mockery::mock(Repository::class));
         $fake->shouldReceive('remember')->once()->with('vapor:schedule:lock', 60, Mockery::any())->andReturn('test-schedule-lock-key');
-        $fake->shouldReceive('forget')->once()->with('illuminate:schedule:interrupt')->andReturn(true);
+        if (version_compare($this->app->version(), 10, '>=')) {
+            $fake->shouldReceive('forget')->once()->with('illuminate:schedule:interrupt')->andReturn(true);
+        }
         $fake->shouldReceive('forget')->once()->with('vapor:schedule:lock')->andReturn(true);
 
         $this->artisan('vapor:schedule')

--- a/tests/Unit/VaporScheduleCommandTest.php
+++ b/tests/Unit/VaporScheduleCommandTest.php
@@ -61,7 +61,7 @@ class VaporScheduleCommandTest extends TestCase
     public function test_scheduler_is_not_invoked_if_lock_cannot_be_obtained()
     {
         Cache::shouldReceive('getDefaultDriver')->once()->andReturn('dynamodb');
-        Cache::shouldReceive('driver')->once()->andReturn($fake = Mockery::mock(Repository::class));
+        Cache::shouldReceive('driver')->andReturn($fake = Mockery::mock(Repository::class));
         $fake->shouldReceive('remember')->once()->with('vapor:schedule:lock', 60, Mockery::any())->andReturn('test-locked-schedule-lock-key');
         $fake->shouldNotReceive('forget')->with('illuminate:schedule:interrupt')->andReturn(true);
         $fake->shouldNotReceive('forget')->with('vapor:schedule:lock');

--- a/tests/Unit/VaporScheduleCommandTest.php
+++ b/tests/Unit/VaporScheduleCommandTest.php
@@ -38,7 +38,7 @@ class VaporScheduleCommandTest extends TestCase
         if (version_compare($this->app->version(), 10, '>=')) {
             $fake->shouldReceive('forget')->once()->with('illuminate:schedule:interrupt')->andReturn(true);
         }
-        if (version_compare($this->app->version(), 9, '!=')) {
+        if (! Str::startsWith($this->app->version(), '9')) {
             Cache::shouldReceive('driver')->once()->andReturn($fake);
         }
         $fake->shouldNotReceive('forget')->with('vapor:schedule:lock');

--- a/tests/Unit/VaporScheduleCommandTest.php
+++ b/tests/Unit/VaporScheduleCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Laravel\Vapor\Tests\Unit;
+
+use Carbon\Carbon;
+use Illuminate\Cache\Repository;
+use Illuminate\Foundation\Testing\WithConsoleEvents;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Laravel\Vapor\VaporServiceProvider;
+use Mockery;
+use Orchestra\Testbench\TestCase;
+
+class VaporScheduleCommandTest extends TestCase
+{
+    use WithConsoleEvents;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow('2021-01-01 00:00:00');
+
+        Str::createUuidsUsing(function () {
+            return 'test-schedule-lock-key';
+        });
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            VaporServiceProvider::class,
+        ];
+    }
+
+    public function test_scheduler_is_invoked_when_invalid_cache_is_configured()
+    {
+        Cache::shouldReceive('getDefaultDriver')->once()->andReturn('array');
+        Cache::shouldReceive('driver')->once()->andReturn($fake = Mockery::mock(Repository::class));
+        $fake->shouldNotReceive('remember');
+        $fake->shouldReceive('forget')->once()->with('illuminate:schedule:interrupt')->andReturn(true);
+        $fake->shouldNotReceive('forget')->with('vapor:schedule:lock');
+
+        $this->artisan('vapor:schedule')
+            ->assertExitCode(0);
+    }
+
+    public function test_scheduler_is_called_at_the_top_of_the_minute()
+    {
+        Cache::shouldReceive('getDefaultDriver')->once()->andReturn('dynamodb');
+        Cache::shouldReceive('driver')->twice()->andReturn($fake = Mockery::mock(Repository::class));
+        $fake->shouldReceive('remember')->once()->with('vapor:schedule:lock', 60, Mockery::any())->andReturn('test-schedule-lock-key');
+        $fake->shouldReceive('forget')->once()->with('illuminate:schedule:interrupt')->andReturn(true);
+        $fake->shouldReceive('forget')->once()->with('vapor:schedule:lock')->andReturn(true);
+
+        $this->artisan('vapor:schedule')
+            ->assertExitCode(0);
+    }
+
+    public function test_scheduler_is_not_invoked_if_lock_cannot_be_obtained()
+    {
+        Cache::shouldReceive('getDefaultDriver')->once()->andReturn('dynamodb');
+        Cache::shouldReceive('driver')->once()->andReturn($fake = Mockery::mock(Repository::class));
+        $fake->shouldReceive('remember')->once()->with('vapor:schedule:lock', 60, Mockery::any())->andReturn('test-locked-schedule-lock-key');
+        $fake->shouldNotReceive('forget')->with('illuminate:schedule:interrupt')->andReturn(true);
+        $fake->shouldNotReceive('forget')->with('vapor:schedule:lock');
+
+        $this->artisan('vapor:schedule')
+            ->assertExitCode(1);
+    }
+}

--- a/tests/Unit/VaporScheduleCommandTest.php
+++ b/tests/Unit/VaporScheduleCommandTest.php
@@ -36,8 +36,10 @@ class VaporScheduleCommandTest extends TestCase
         Cache::shouldReceive('getDefaultDriver')->once()->andReturn('array');
         $fake->shouldNotReceive('remember');
         if (version_compare($this->app->version(), 10, '>=')) {
-            Cache::shouldReceive('driver')->once()->andReturn($fake);
             $fake->shouldReceive('forget')->once()->with('illuminate:schedule:interrupt')->andReturn(true);
+        }
+        if (version_compare($this->app->version(), 9, '!=')) {
+            Cache::shouldReceive('driver')->once()->andReturn($fake);
         }
         $fake->shouldNotReceive('forget')->with('vapor:schedule:lock');
 

--- a/tests/Unit/VaporScheduleCommandTest.php
+++ b/tests/Unit/VaporScheduleCommandTest.php
@@ -32,10 +32,11 @@ class VaporScheduleCommandTest extends TestCase
 
     public function test_scheduler_is_invoked_when_invalid_cache_is_configured()
     {
+        $fake = Mockery::mock(Repository::class);
         Cache::shouldReceive('getDefaultDriver')->once()->andReturn('array');
-        Cache::shouldReceive('driver')->once()->andReturn($fake = Mockery::mock(Repository::class));
         $fake->shouldNotReceive('remember');
         if (version_compare($this->app->version(), 10, '>=')) {
+            Cache::shouldReceive('driver')->once()->andReturn($fake);
             $fake->shouldReceive('forget')->once()->with('illuminate:schedule:interrupt')->andReturn(true);
         }
         $fake->shouldNotReceive('forget')->with('vapor:schedule:lock');
@@ -47,7 +48,7 @@ class VaporScheduleCommandTest extends TestCase
     public function test_scheduler_is_called_at_the_top_of_the_minute()
     {
         Cache::shouldReceive('getDefaultDriver')->once()->andReturn('dynamodb');
-        Cache::shouldReceive('driver')->twice()->andReturn($fake = Mockery::mock(Repository::class));
+        Cache::shouldReceive('driver')->andReturn($fake = Mockery::mock(Repository::class));
         $fake->shouldReceive('remember')->once()->with('vapor:schedule:lock', 60, Mockery::any())->andReturn('test-schedule-lock-key');
         if (version_compare($this->app->version(), 10, '>=')) {
             $fake->shouldReceive('forget')->once()->with('illuminate:schedule:interrupt')->andReturn(true);


### PR DESCRIPTION
Vapor's scheduler is invoked every minute by EventBridge. Unlike cron, this is not guaranteed to run at the top of every minute - in fact, here's a note from the AWS docs:

> The finest resolution for an EventBridge rule that uses a cron expression is one minute. Your scheduled rule runs within that minute but not on the precise 0th second.
>
> Because EventBridge and target services are distributed, there can be a delay of several seconds between the time the scheduled rule runs and the time the target service performs the action on the target resource.

This is problematic when it comes to sub-minute scheduling which is pretty reliant on the scheduler being invoked at the top of the minute.

In a scenario where an app is running a command using the `everySecond()` method and where EventBridge doesn't invoke the CLI function until 45s after the top of the minute, the command will actually only run on seconds 45-59 - not ideal.

This PR attempts to remedy that like so:

A new `vapor:schedule` command has been added. Its job is to act as a sort of proxy between EventBridge and the Laravel scheduler in order to normalize the invocations to the top of the minute.

The first invocation will acquire a lock from the configured cache. This will happen at whatever time it receives the invocation and it keeps the lock until the top of the next minute is reached. At this point, `$this->call('schedule:run`);` is called and the lock is released.

Now, the next container invoked by EventBridge will attempt to grab the lock. In the event it is invoked prior to the first invocation finishing, it will wait for the lock to be freed. When the lock has been acquired, it waits for the top of the next minute and invokes Laravel's scheduler.

Rinse and repeat.

In the event an unsuitable cache is configured, the command will immediately fallback to `schedule:run`.

One thing to consider here is that the `cli-timeout` will need to be set to >= 120 to ensure there is enough time to cover the up to 60s wait to invoke the scheduler and to allow the scheduler to run the repeat events of the sub-minute schedule.