### PR TITLE
Rename typo in job key

### DIFF
--- a/src/Queue/JobAttempts.php
+++ b/src/Queue/JobAttempts.php
@@ -104,6 +104,6 @@ class JobAttempts
     {
         $jobId = $job instanceof Job ? $job->getJobId() : $job;
 
-        return 'laravel_vapor_job_attemps:'.$jobId;
+        return 'laravel_vapor_job_attempts:'.$jobId;
     }
 }


### PR DESCRIPTION
The Vapor queue key has a small typo: laravel_vapor_job_attemps. Changed it to laravel_vapor_job_attempts