### PR TITLE
[2.x] Adds support for serverless ElastiCache

### DIFF
--- a/src/ConfiguresRedis.php
+++ b/src/ConfiguresRedis.php
@@ -20,9 +20,14 @@ trait ConfiguresRedis
 
         Config::set('database.redis', array_merge(Arr::except(Config::get('database.redis', []), ['default', 'cache']), [
             'client' => $_ENV['REDIS_CLIENT'] ?? 'phpredis',
-            'options' => array_merge(Config::get('database.redis.options', []), [
-                'cluster' => $_ENV['REDIS_CLUSTER'] ?? 'redis',
-            ]),
+            'options' => array_merge(
+                Config::get('database.redis.options', []),
+                array_filter([
+                    'cluster' => $_ENV['REDIS_CLUSTER'] ?? 'redis',
+                    'scheme' => $_ENV['REDIS_SCHEME'] ?? null,
+                    'context' => array_filter(['cafile' => $_ENV['REDIS_SSL_CA'] ?? null]),
+                ])
+            ),
             'clusters' => array_merge(Config::get('database.redis.clusters', []), [
                 'default' => [
                     [


### PR DESCRIPTION
This PR updates the Redis config to set the CA file in the SSL context option which is required for serverless ElastiCache.