### PR TITLE
Enhanced Static Asset Serving from Public Directory

### DIFF
--- a/src/Http/Middleware/ServeStaticAssets.php
+++ b/src/Http/Middleware/ServeStaticAssets.php
@@ -27,6 +27,15 @@ class ServeStaticAssets
                 return $response;
             }
 
+            if (file_exists($path = public_path($requestUri))) {
+                $content = file_get_contents($path);
+
+                return response($content)->withHeaders([
+                    'Content-Length' => strlen($content),
+                    'Content-Type' => mime_content_type($path),
+                ]);
+            }
+
             $asset = null;
 
             try {


### PR DESCRIPTION
This pull request enhances the `ServeStaticAssets` middleware, enabling it to serve static assets directly from the public directory. I believe this change significantly boosts performance by reducing the overhead associated with S3 URL requests.