### PR TITLE
[2.x] Gracefully fix typo in cache key

### DIFF
--- a/src/Queue/JobAttempts.php
+++ b/src/Queue/JobAttempts.php
@@ -22,7 +22,6 @@ class JobAttempts
     /**
      * Create a new job attempts instance.
      *
-     * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @return void
      */
     public function __construct(Cache $cache)
@@ -104,6 +103,15 @@ class JobAttempts
     {
         $jobId = $job instanceof Job ? $job->getJobId() : $job;
 
-        return 'laravel_vapor_job_attemps:'.$jobId;
+        $oldKey = 'laravel_vapor_job_attemps:'.$jobId;
+        $newKey = 'laravel_vapor_job_attempts:'.$jobId;
+
+        if (($value = $this->cache->get($oldKey)) !== null) {
+            $this->cache->put($newKey, $value, static::TTL);
+
+            $this->cache->forget($oldKey);
+        }
+
+        return $newKey;
     }
 }


### PR DESCRIPTION
This PR addresses a typo in the `JobAttempts` cache key.

We can't simply rename the key as, once deployed, it would reset the counter for all jobs currently being processed.

Instead, we can check whether a value exists with the old key and set the value on the new key if it does.

This will of course add at least one extra read from the cache per job attempt.