### PR TITLE
Use VAPOR_ENV for non-standard environment option

### DIFF
--- a/src/Runtime/Environment.php
+++ b/src/Runtime/Environment.php
@@ -60,7 +60,7 @@ class Environment
     {
         $this->app = $app;
 
-        $this->environment = $_ENV['APP_ENV'] ?? 'production';
+        $this->environment = $_ENV['VAPOR_ENV'] ?? $_ENV['APP_ENV'] ?? 'production';
         $this->environmentFile = '.env.'.$this->environment;
         $this->encryptedFile = '.env.'.$this->environment.'.encrypted';
     }


### PR DESCRIPTION
Vapor lets you set up multiple environments, each with its own name. While they are different environments, they may all still run in "production mode" with `APP_ENV=production`. But the encrypted environment variables each Vapor environment needs will be different.

The issue is that the naming convention of `.env.production.encrypted` in the root of the repository does not allow for storing encrypted environment variables for multiple Vapor environments that run in production mode.

This PR introduces `VAPOR_ENV` to mirror the environment name used for each Vapor environment. (In our case, we use `dev`, `demo` and `production` -- sometimes `staging`.) FWIW we use `STAGE` as the environment variable to distinguish environments, but `VAPOR_ENV` would be less opinionated.