### PR TITLE
AWS_URL and AWS_ENDPOINT

### DIFF
--- a/src/Http/Controllers/SignedStorageUrlController.php
+++ b/src/Http/Controllers/SignedStorageUrlController.php
@@ -134,8 +134,11 @@ class SignedStorageUrlController extends Controller implements SignedStorageUrlC
 
             if (array_key_exists('AWS_URL', $_ENV) && ! is_null($_ENV['AWS_URL'])) {
                 $config['url'] = $_ENV['AWS_URL'];
-                $config['endpoint'] = $_ENV['AWS_URL'];
             }
+
+            if (array_key_exists('AWS_ENDPOINT', $_ENV) && ! is_null($_ENV['AWS_ENDPOINT'])) {
+                $config['endpoint'] = $_ENV['AWS_ENDPOINT'];
+            } 
         }
 
         return new S3Client($config);


### PR DESCRIPTION
Please forgive my using a pull request to communicate this, but I couldn't figure out a more appropriate or efficiency method.

I am working on switching us to using transfer acceleration for our S3 bucket. It seemed like the way to do this for the Laravel Storage facade and filesystem was to simply set a value in the environment for `AWS_ENDPOINT`, and in fact that works just fine. But based on the code in `SignedStorageUrlController`, it looks like I also have to set `AWS_URL` to achieve the same thing for Vapor file uploads.

I'm just curious about this difference, and if it is intentional, what is the reason? I want to make sure I am implementing all of this correctly. Thank you!