### PR TITLE
Utilise raw query string from the lambda event

### DIFF
--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -110,11 +110,9 @@ class Request
 
         $queryString = self::getQueryString($event);
 
-        parse_str($queryString, $queryParameters);
-
         return [
             empty($queryString) ? $uri : $uri.'?'.$queryString,
-            http_build_query($queryParameters),
+            $queryString,
         ];
     }
 
@@ -127,16 +125,7 @@ class Request
     protected static function getQueryString(array $event)
     {
         if (isset($event['version']) && $event['version'] === '2.0') {
-            return http_build_query(
-                collect($event['queryStringParameters'] ?? [])
-                ->mapWithKeys(function ($value, $key) {
-                    $values = explode(',', $value);
-
-                    return count($values) === 1
-                        ? [$key => $values[0]]
-                        : [(substr($key, -2) == '[]' ? substr($key, 0, -2) : $key) => $values];
-                })->all()
-            );
+            return $event['rawQueryString'];
         }
 
         if (! isset($event['multiValueQueryStringParameters'])) {

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -93,6 +93,7 @@ class FpmRequestTest extends TestCase
                     'protocol' => 'HTTP/1.1',
                 ],
             ],
+            'rawQueryString' => 'key1=value1&key2[]=value2&key2[]=value3',
             'queryStringParameters' => [
                 'key1' => 'value1',
                 'key2' => 'value2,value3',
@@ -100,10 +101,7 @@ class FpmRequestTest extends TestCase
         ]);
 
         $this->assertSame(
-            http_build_query([
-                'key1' => 'value1',
-                'key2' => ['value2', 'value3'],
-            ]),
+            'key1=value1&key2[]=value2&key2[]=value3',
             $request->serverVariables['QUERY_STRING']
         );
     }


### PR DESCRIPTION
The way query parameters are parsed from the lambda event (using `queryStringParameters` from the payload and building into a string via `http_build_query`) means that the query parameter string may be different to how it was originally sent in the request.

E.g. a URL with `?key[]=value1&key[]=value2` will become `?key%5B0%5D=value1&key%5B1%5D=value2`

This has caused some headaches when using the ignore parameter feature of laravel URL signature validation. E.g. instead of specifying `key[]` as a parameter to ignore you'd have to add both `key%5B0%5D` and `key%5B1%5D` as the array index is also added when using `http_build_query`.

As it appears there is a `rawQueryString` property available in the [AWS Lambda payload format structure](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format-structure) I feel like it might be sensible to use this when available.

It reduces the work that is done in this library and means that the `Request` is closer to what you would expect in other server environments. It also means that the original query string format will be retained.