### PR TITLE
Remove redundant calls to http_build_query

### DIFF
--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -110,11 +110,9 @@ class Request
 
         $queryString = self::getQueryString($event);
 
-        parse_str($queryString, $queryParameters);
-
         return [
             empty($queryString) ? $uri : $uri.'?'.$queryString,
-            http_build_query($queryParameters),
+            $queryString,
         ];
     }
 

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -25,7 +25,10 @@ class FpmRequestTest extends TestCase
             ],
         ]);
 
-        $this->assertSame(http_build_query(['Host' => urldecode($host)]), $request->serverVariables['QUERY_STRING']);
+        $query = http_build_query(['Host' => urldecode($host)]);
+
+        $this->assertSame($query, $request->serverVariables['QUERY_STRING']);
+        $this->assertSame('/?'.$query, $request->serverVariables['REQUEST_URI']);
     }
 
     public function test_api_gateway_headers_are_handled()
@@ -99,13 +102,13 @@ class FpmRequestTest extends TestCase
             ],
         ]);
 
-        $this->assertSame(
-            http_build_query([
-                'key1' => 'value1',
-                'key2' => ['value2', 'value3'],
-            ]),
-            $request->serverVariables['QUERY_STRING']
-        );
+        $query = http_build_query([
+            'key1' => 'value1',
+            'key2' => ['value2', 'value3'],
+        ]);
+
+        $this->assertSame($query, $request->serverVariables['QUERY_STRING']);
+        $this->assertSame('/?'.$query, $request->serverVariables['REQUEST_URI']);
     }
 
     public function test_load_balancer_headers_are_over_spoofed_headers()


### PR DESCRIPTION
One of the things I noticed in #181 is that there's unnecessary calls to `parse_str` and `http_build_query` happening in `getUriAndQueryString`.

The values from `getQueryString` already go through `http_build_query` so it seems unnecessary to reparse it and build it again. Should just reduce the work vapor-core has to do every request.