### PR TITLE
[2.x] Reset scoped instances before running a new vapor job

### DIFF
--- a/src/ConfiguresQueue.php
+++ b/src/ConfiguresQueue.php
@@ -5,6 +5,7 @@ namespace Laravel\Vapor;
 use Illuminate\Cache\NullStore;
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\Facades\Facade;
 use Laravel\Vapor\Queue\JobAttempts;
 use Laravel\Vapor\Queue\VaporWorker;
 

--- a/src/ConfiguresQueue.php
+++ b/src/ConfiguresQueue.php
@@ -5,7 +5,6 @@ namespace Laravel\Vapor;
 use Illuminate\Cache\NullStore;
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
-use Illuminate\Support\Facades\Facade;
 use Laravel\Vapor\Queue\JobAttempts;
 use Laravel\Vapor\Queue\VaporWorker;
 

--- a/src/Queue/VaporWorker.php
+++ b/src/Queue/VaporWorker.php
@@ -18,6 +18,8 @@ class VaporWorker extends Worker
      */
     public function runVaporJob($job, $connectionName, WorkerOptions $options)
     {
+        app()->forgetScopedInstances();
+
         pcntl_async_signals(true);
 
         pcntl_signal(SIGALRM, function () use ($job) {


### PR DESCRIPTION
Scoped instances weren't reset between job on Vapor. This is because the framework resets the scope inside the daemon function that vapor doesn't use.

https://linear.app/laravel/issue/CORE-329/scoped-bindings-dont-work-on-vapor-queues