### PR TITLE
Fix Octane cookies for v2

### DIFF
--- a/tests/Feature/LambdaProxyOctaneHandlerTest.php
+++ b/tests/Feature/LambdaProxyOctaneHandlerTest.php
@@ -396,8 +396,8 @@ EOF
                     'path' => '/',
                 ],
             ],
-            'headers' => [
-                'cookie' => 'XSRF-TOKEN=token_value',
+            'cookies' => [
+                'XSRF-TOKEN=token_value',
             ],
         ]);
 
@@ -423,8 +423,9 @@ EOF
                     'path' => '/',
                 ],
             ],
-            'headers' => [
-                'cookie' => 'cookieKey1; cookieKey2=cookieValue2',
+            'cookies' => [
+                'cookieKey1',
+                'cookieKey2=cookieValue2',
             ],
         ]);
 


### PR DESCRIPTION
In the v2 payload, cookies are moved to a separate field instead of being added to the headers, so they must be processed in a different way

AWS documentation:
> Format 2.0 includes a new cookies field. All cookie headers in the request are combined with commas and added to the cookies field

[Documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format)