### PR TITLE
Fix parsing multidimensional array from multipart

### DIFF
--- a/src/Arr.php
+++ b/src/Arr.php
@@ -65,10 +65,12 @@ class Arr
                 return $array;
             }
 
+            $segment = substr($segment, 0, -1);
+
             // If the segment is empty after trimming off the closing bracket, it means
             // we are at the end of the segment and are ready to set the value so we
             // can grab a pointer to the array location and set it after the loop.
-            if (empty($segment = substr($segment, 0, -1))) {
+            if ($segment === '') {
                 $pointer = &$pointer[];
             } else {
                 $pointer = &$pointer[$segment];


### PR DESCRIPTION
During parsing a multipart array there is a check if the current segment is empty to set a value. Basically, adding a new element to an array.

It works perfectly fine for simple arrays like:

- 'categories[]: 1'
- 'categories[]: 2'

But sometimes the array key is also specified, fx:

- 'categories[0]: 1'
- 'categories[1]: 2'

Or something more complicated as Laravel Nova does:

- 'options[0][fields][id]: 1'
- 'options[0][fields][participants]: 1'

In that case the check:

```php
if (empty($segment = substr($segment, 0, -1))) {
    $pointer = &$pointer[];
} else {
    $pointer = &$pointer[$segment];
}
```
Will fail as `empty` considers the first array key ('0') as true
![image](https://github.com/user-attachments/assets/9c263ccc-78f4-488e-9df1-c76b98279f5e)
Thus each time a new array element created instead of adding to the existing one, which causes some unexpected result

Report to that issue in the Nova issues repository: https://github.com/laravel/nova-issues/issues/6229