### PR TITLE
Add explicit null for php 8.4 deprecation warning fix

### DIFF
--- a/src/VaporJobTimedOutException.php
+++ b/src/VaporJobTimedOutException.php
@@ -13,7 +13,7 @@ class VaporJobTimedOutException extends Exception
      * @param  string  $name
      * @param  Throwable|null  $previous
      */
-    public function __construct($name, Throwable $previous = null)
+    public function __construct($name, ?Throwable $previous = null)
     {
         parent::__construct($name.' has timed out. It will be retried again.', 0, $previous);
     }


### PR DESCRIPTION
Added an explicit nullable since implicit null is deprecated in php 8.4. 

Gets rid of deprecation warnings.


See: 
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated
