### PR TITLE
Fix missing write permission for changelog updater

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -6,4 +6,6 @@ on:
 
 jobs:
   update:
+    permissions:
+      contents: write
     uses: laravel/.github/.github/workflows/update-changelog.yml@main


### PR DESCRIPTION
The changelog updater does not have access to write to the repo anymore, so we need to explicitly set it.