### PR TITLE
Add `flushState` method to reset static variables in `VaporWorkCommand`

### DIFF
--- a/src/Console/Commands/VaporWorkCommand.php
+++ b/src/Console/Commands/VaporWorkCommand.php
@@ -207,4 +207,14 @@ class VaporWorkCommand extends Command
 
         return false;
     }
+
+    /**
+     * Reset static variables.
+     *
+     * @return void
+     */
+    public static function flushState()
+    {
+        static::$listeningForEvents = false;
+    }
 }


### PR DESCRIPTION
This PR adds a `flushState` method to `VaporWorkCommand`, to reset static variables, mirroring the `flushState` method in the framework's `WorkCommand`.

https://github.com/laravel/framework/blob/5ad0a1c079f8a8dda603c97333864b7ef4b11d20/src/Illuminate/Queue/Console/WorkCommand.php#L379-L387

This would be useful when testing jobs via the `vapor:work` command.
e.g. https://github.com/laravel/nightwatch/pull/199