### PR TITLE
Add API Gateway request timestamp to server variables

### DIFF
--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -275,7 +275,6 @@ class Request
      * Extracts the time (millisecond epoch) when the request was received by the API Gateway.
      *
      * @param  array  $event
-     *
      * @return int|null
      */
     protected static function extractRequestTimestamp(array $event)

--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -280,11 +280,11 @@ class Request
     protected static function extractRequestTimestamp(array $event)
     {
         if (! isset($event['requestContext'])) {
-            return null; // No requestContext, so no timestamp available
+            return null;
         }
 
         return $event['requestContext']['requestTimeEpoch'] // REST API (V1)
             ?? $event['requestContext']['timeEpoch']        // HTTP API (V2)
-            ?? null; // ELB doesn't add a timestamp
+            ?? null;
     }
 }

--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -79,6 +79,10 @@ class Request
             $serverVariables['SCRIPT_FILENAME'] = $handler;
         }
 
+        if ($timestamp = self::extractRequestTimestamp($event)) {
+            $serverVariables['AWS_API_GATEWAY_REQUEST_TIME'] = $timestamp;
+        }
+
         [$headers, $serverVariables] = static::ensureContentTypeIsSet(
             $event, $headers, $serverVariables
         );
@@ -265,5 +269,23 @@ class Request
         }
 
         return $headers;
+    }
+
+    /**
+     * Extracts the time (millisecond epoch) when the request was received by the API Gateway.
+     *
+     * @param  array  $event
+     *
+     * @return int|null
+     */
+    protected static function extractRequestTimestamp(array $event)
+    {
+        if (! isset($event['requestContext'])) {
+            return null; // No requestContext, so no timestamp available
+        }
+
+        return $event['requestContext']['requestTimeEpoch'] // REST API (V1)
+            ?? $event['requestContext']['timeEpoch']        // HTTP API (V2)
+            ?? null; // ELB doesn't add a timestamp
     }
 }

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -2,12 +2,20 @@
 
 namespace Laravel\Vapor\Tests\Unit;
 
+use Carbon\Carbon;
 use Laravel\Vapor\Runtime\Fpm\FpmRequest;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class FpmRequestTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow('2021-01-01 00:00:00');
+    }
+
     protected function tearDown(): void
     {
         Mockery::close();
@@ -181,5 +189,42 @@ class FpmRequestTest extends TestCase
         ]);
 
         $this->assertSame(0, $request->getContentLength());
+    }
+
+    public function test_api_gateway_v1_request_time_is_set()
+    {
+        $epoch = Carbon::now()->getPreciseTimestamp(3);
+
+        $request = FpmRequest::fromLambdaEvent([
+            'httpMethod' => 'GET',
+            'requestContext' => [
+                'requestTimeEpoch' => $epoch,
+            ],
+        ]);
+
+        $this->assertSame($epoch, $request->serverVariables['AWS_API_GATEWAY_REQUEST_TIME']);
+    }
+
+    public function test_api_gateway_v2_request_time_is_set()
+    {
+        $epoch = Carbon::now()->getPreciseTimestamp(3);
+
+        $request = FpmRequest::fromLambdaEvent([
+            'httpMethod' => 'GET',
+            'requestContext' => [
+                'timeEpoch' => $epoch,
+            ],
+        ]);
+
+        $this->assertSame($epoch, $request->serverVariables['AWS_API_GATEWAY_REQUEST_TIME']);
+    }
+
+    public function test_elb_request_time_is_not_set()
+    {
+        $request = FpmRequest::fromLambdaEvent([
+            'httpMethod' => 'GET',
+        ]);
+
+        $this->assertArrayNotHasKey('AWS_API_GATEWAY_REQUEST_TIME', $request->serverVariables);
     }
 }


### PR DESCRIPTION
This PR adds support for extracting the original request timestamp from the API Gateway event (`requestContext.requestTimeEpoch` or `requestContext.timeEpoch`) and exposes it in the `$_SERVER` array as `AWS_API_GATEWAY_REQUEST_TIME`.

This enables more accurate request duration tracking and allows downstream code to calculate cold start latency by comparing the API Gateway arrival time to actual execution time.

The timestamp is derived directly from the incoming event and kept within the request context rather than being set as a global environment variable. This keeps the data scoped to the request lifecycle and avoids side effects across concurrent executions.

If preferred, I’m happy to revise this to expose it via an environment variable or another mechanism.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
