### PR TITLE
fix: Avoid Filtering Failed Jobs Timestamp in Memory

### DIFF
--- a/src/Console/Commands/VaporQueueListFailedCommand.php
+++ b/src/Console/Commands/VaporQueueListFailedCommand.php
@@ -43,12 +43,25 @@ class VaporQueueListFailedCommand extends Command
      */
     public function handle()
     {
-        $failed = $this->laravel['queue.failer']->all();
-
         $options = collect($this->options())
             ->filter(function ($value, $option) {
                 return ! is_null($value) && in_array($option, ['id', 'queue', 'query', 'start']);
             });
+
+        $failer = $this->laravel['queue.failer'];
+        $start = $this->option('start');
+
+        if (is_callable([$failer, 'getTable']) && $start) {
+            $failed = $failer->getTable()
+                ->where('failed_at', '>=', Carbon::createFromTimestamp($start)->toDateTimeString())
+                ->get();
+
+            $options = $options->reject(function ($value, $name) {
+                return $name === 'start';
+            });
+        } else {
+            $failed = $failer->all();
+        }
 
         $failedJobs = collect($failed)->filter(function ($job) use ($options) {
             return $options->every(function ($value, $option) use ($job) {


### PR DESCRIPTION
To display queue metrics, Vapor loads all `failed_jobs` and filters the period (1m, 5m, 10m, 30m, 1h, 24h, 7d, 30d) in memory. When the `failed_jobs` table has a large number of rows, usually as a result of not pruning `failed_jobs` on a regular basis, it would cause Queue Metrics to fail with HTTP status 502.

`getTable` was made public via https://github.com/laravel/framework/pull/56384

As a workaround, we could run the following as a command:

```php
php artisan queue:prune-failed --hours=720
```

Or we could also add this as a scheduled job:

```php
Schedule::command('queue:prune-failed --hours=720')
    ->daily();
```

This will delete every failed job that is older than 30 days.

Note: In another PR, we could also filter all the other filter options (id, queue, query)