### PR TITLE
Expose AWS Lambda execution context for Vapor logging

### DIFF
--- a/src/HasAwsContext.php
+++ b/src/HasAwsContext.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Laravel\Vapor;
+
+trait HasAwsContext
+{
+    /**
+     * Get the current AWS request ID.
+     *
+     * @return string|null The AWS request ID if available.
+     */
+    public static function requestId(): ?string
+    {
+        return $_ENV['AWS_REQUEST_ID'] ?? null;
+    }
+
+    /**
+     * Get the AWS Lambda function name.
+     *
+     * @return string|null The Lambda function name if available.
+     */
+    public static function functionName(): ?string
+    {
+        return $_ENV['AWS_LAMBDA_FUNCTION_NAME'] ?? null;
+    }
+
+    /**
+     * Get the AWS Lambda function version.
+     *
+     * @return string|null The Lambda function version if available.
+     */
+    public static function functionVersion(): ?string
+    {
+        return $_ENV['AWS_LAMBDA_FUNCTION_VERSION'] ?? null;
+    }
+
+    /**
+     * Get the AWS CloudWatch log group name.
+     *
+     * @return string|null The CloudWatch log group name if available.
+     */
+    public static function logGroupName(): ?string
+    {
+        return $_ENV['AWS_LAMBDA_LOG_GROUP_NAME'] ?? null;
+    }
+
+    /**
+     * Get the AWS CloudWatch log stream name.
+     *
+     * @return string|null The CloudWatch log stream name if available.
+     */
+    public static function logStreamName(): ?string
+    {
+        return $_ENV['AWS_LAMBDA_LOG_STREAM_NAME'] ?? null;
+    }
+
+    /**
+     * Get the AWS execution context for the current Vapor environment.
+     *
+     * @return array{
+     *     request_id: string|null,
+     *     function_name: string|null,
+     *     function_version: string|null,
+     *     log_group_name: string|null,
+     *     log_stream_name: string|null
+     * }
+     */
+    protected function awsContext(): array
+    {
+        return [
+            'request_id' => self::requestId(),
+            'function_name' => self::functionName(),
+            'function_version' => self::functionVersion(),
+            'log_group_name' => self::logGroupName(),
+            'log_stream_name' => self::logStreamName(),
+        ];
+    }
+}

--- a/src/Vapor.php
+++ b/src/Vapor.php
@@ -4,6 +4,9 @@ namespace Laravel\Vapor;
 
 class Vapor
 {
+
+    use HasAwsContext;
+
     /**
      * Determine whether the environment is Vapor.
      */

--- a/src/Vapor.php
+++ b/src/Vapor.php
@@ -4,7 +4,6 @@ namespace Laravel\Vapor;
 
 class Vapor
 {
-
     use HasAwsContext;
 
     /**


### PR DESCRIPTION
# Expose AWS Lambda execution context for Vapor logging

## Overview

Debugging production issues in Vapor can be difficult when attempting to correlate application logs with their corresponding AWS CloudWatch entries.

This change introduces a small helper trait that exposes commonly needed AWS Lambda execution metadata directly from the environment, including the request ID, function name, function version, and CloudWatch log identifiers.

## Motivation

Providing easy access to this context allows logs and exceptions to include Lambda-specific identifiers, making it significantly easier to locate the relevant log stream in CloudWatch and trace individual requests during debugging.

## Details

The helper is lightweight, has no external dependencies, and can be used wherever logging or error reporting occurs. It does not modify existing behavior and introduces no breaking changes.

## Benefits

- Improves log traceability in Vapor environments
- Reduces time spent locating CloudWatch logs
- Enhances production debugging without additional overhead