### PR TITLE
Add dynamic cli handler factory.

### DIFF
--- a/src/Runtime/CliHandlerFactory.php
+++ b/src/Runtime/CliHandlerFactory.php
@@ -8,11 +8,11 @@ use Laravel\Vapor\Runtime\Handlers\QueueHandler;
 class CliHandlerFactory
 {
     /**
-     * The custom handler resolver callback.
+     * The custom handler factory callback.
      *
      * @var callable|null
      */
-    protected static $customHandlerResolver;
+    protected static $customHandlerFactory;
 
     /**
      * Create a new handler for the given CLI event.
@@ -22,50 +22,37 @@ class CliHandlerFactory
      */
     public static function make(array $event)
     {
-        return static::shouldHandleAsQueueJob($event)
-                    ? new QueueHandler
-                    : new CliHandler;
-    }
-
-    /**
-     * Determine if the event should be handled as a queue job.
-     *
-     * @param  array  $event
-     * @return bool
-     */
-    protected static function shouldHandleAsQueueJob(array $event)
-    {
-        if (static::$customHandlerResolver) {
-            return call_user_func(static::$customHandlerResolver, $event);
+        if (static::$customHandlerFactory) {
+            return call_user_func(static::$customHandlerFactory, $event);
         }
 
         $messageId = $event['Records'][0]['messageId'] ?? null;
 
         $job = json_decode($event['Records'][0]['body'] ?? '')->job ?? null;
 
-        return $messageId && $job;
+        return $messageId && $job
+                    ? new QueueHandler
+                    : new CliHandler;
     }
 
     /**
-     * Set a custom handler resolver callback.
-     *
-     * The callback should return true for queue jobs, false for CLI events.
+     * Set a custom handler factory callback.
      *
      * @param  callable  $callback
      * @return void
      */
-    public static function resolveHandlerUsing(callable $callback)
+    public static function createHandlerUsing(callable $callback)
     {
-        static::$customHandlerResolver = $callback;
+        static::$customHandlerFactory = $callback;
     }
 
     /**
-     * Reset the handler resolver to its default behavior.
+     * Reset the handler factory to its default behavior.
      *
      * @return void
      */
-    public static function resolveHandlersNormally()
+    public static function createHandlersNormally()
     {
-        static::$customHandlerResolver = null;
+        static::$customHandlerFactory = null;
     }
 }

--- a/src/Runtime/CliHandlerFactory.php
+++ b/src/Runtime/CliHandlerFactory.php
@@ -8,6 +8,13 @@ use Laravel\Vapor\Runtime\Handlers\QueueHandler;
 class CliHandlerFactory
 {
     /**
+     * The custom handler resolver callback.
+     *
+     * @var callable|null
+     */
+    protected static $customHandlerResolver;
+
+    /**
      * Create a new handler for the given CLI event.
      *
      * @param  array  $event
@@ -15,12 +22,50 @@ class CliHandlerFactory
      */
     public static function make(array $event)
     {
+        return static::shouldHandleAsQueueJob($event)
+                    ? new QueueHandler
+                    : new CliHandler;
+    }
+
+    /**
+     * Determine if the event should be handled as a queue job.
+     *
+     * @param  array  $event
+     * @return bool
+     */
+    protected static function shouldHandleAsQueueJob(array $event)
+    {
+        if (static::$customHandlerResolver) {
+            return call_user_func(static::$customHandlerResolver, $event);
+        }
+
         $messageId = $event['Records'][0]['messageId'] ?? null;
 
         $job = json_decode($event['Records'][0]['body'] ?? '')->job ?? null;
 
-        return $messageId && $job
-                    ? new QueueHandler
-                    : new CliHandler;
+        return $messageId && $job;
+    }
+
+    /**
+     * Set a custom handler resolver callback.
+     *
+     * The callback should return true for queue jobs, false for CLI events.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public static function resolveHandlerUsing(callable $callback)
+    {
+        static::$customHandlerResolver = $callback;
+    }
+
+    /**
+     * Reset the handler resolver to its default behavior.
+     *
+     * @return void
+     */
+    public static function resolveHandlersNormally()
+    {
+        static::$customHandlerResolver = null;
     }
 }

--- a/tests/Unit/Runtime/CliHandlerFactoryTest.php
+++ b/tests/Unit/Runtime/CliHandlerFactoryTest.php
@@ -16,6 +16,13 @@ class CliHandlerFactoryTest extends TestCase
         QueueHandler::$app = 'dummy';
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        CliHandlerFactory::resolveHandlersNormally();
+    }
+
     public function test_custom_sqs_events_use_cli_handler()
     {
         $this->assertInstanceOf(CliHandler::class, CliHandlerFactory::make($this->getSQSCustomEvent()));
@@ -28,6 +35,42 @@ class CliHandlerFactoryTest extends TestCase
 
     public function test_laravel_jobs_use_queue_handler()
     {
+        $this->assertInstanceOf(QueueHandler::class, CliHandlerFactory::make($this->getSQSJobEvent()));
+    }
+
+    public function test_custom_handler_resolver_is_used_when_set()
+    {
+        CliHandlerFactory::resolveHandlerUsing(function ($event) {
+            return false;
+        });
+
+        $this->assertInstanceOf(CliHandler::class, CliHandlerFactory::make($this->getSQSJobEvent()));
+    }
+
+    public function test_custom_handler_resolver_receives_event()
+    {
+        $receivedEvent = null;
+
+        CliHandlerFactory::resolveHandlerUsing(function ($event) use (&$receivedEvent) {
+            $receivedEvent = $event;
+
+            return false;
+        });
+
+        $expectedEvent = $this->getSQSJobEvent();
+        CliHandlerFactory::make($expectedEvent);
+
+        $this->assertSame($expectedEvent, $receivedEvent);
+    }
+
+    public function test_default_behavior_is_restored_after_reset()
+    {
+        CliHandlerFactory::resolveHandlerUsing(function ($event) {
+            return false;
+        });
+
+        CliHandlerFactory::resolveHandlersNormally();
+
         $this->assertInstanceOf(QueueHandler::class, CliHandlerFactory::make($this->getSQSJobEvent()));
     }
 

--- a/tests/Unit/Runtime/CliHandlerFactoryTest.php
+++ b/tests/Unit/Runtime/CliHandlerFactoryTest.php
@@ -20,7 +20,7 @@ class CliHandlerFactoryTest extends TestCase
     {
         parent::tearDown();
 
-        CliHandlerFactory::resolveHandlersNormally();
+        CliHandlerFactory::createHandlersNormally();
     }
 
     public function test_custom_sqs_events_use_cli_handler()
@@ -38,23 +38,23 @@ class CliHandlerFactoryTest extends TestCase
         $this->assertInstanceOf(QueueHandler::class, CliHandlerFactory::make($this->getSQSJobEvent()));
     }
 
-    public function test_custom_handler_resolver_is_used_when_set()
+    public function test_custom_handler_factory_is_used_when_set()
     {
-        CliHandlerFactory::resolveHandlerUsing(function ($event) {
-            return false;
+        CliHandlerFactory::createHandlerUsing(function ($event) {
+            return new CliHandler;
         });
 
         $this->assertInstanceOf(CliHandler::class, CliHandlerFactory::make($this->getSQSJobEvent()));
     }
 
-    public function test_custom_handler_resolver_receives_event()
+    public function test_custom_handler_factory_receives_event()
     {
         $receivedEvent = null;
 
-        CliHandlerFactory::resolveHandlerUsing(function ($event) use (&$receivedEvent) {
+        CliHandlerFactory::createHandlerUsing(function ($event) use (&$receivedEvent) {
             $receivedEvent = $event;
 
-            return false;
+            return new CliHandler;
         });
 
         $expectedEvent = $this->getSQSJobEvent();
@@ -65,11 +65,11 @@ class CliHandlerFactoryTest extends TestCase
 
     public function test_default_behavior_is_restored_after_reset()
     {
-        CliHandlerFactory::resolveHandlerUsing(function ($event) {
-            return false;
+        CliHandlerFactory::createHandlerUsing(function ($event) {
+            return new CliHandler;
         });
 
-        CliHandlerFactory::resolveHandlersNormally();
+        CliHandlerFactory::createHandlersNormally();
 
         $this->assertInstanceOf(QueueHandler::class, CliHandlerFactory::make($this->getSQSJobEvent()));
     }


### PR DESCRIPTION
This PR adds the ability to customize how `CliHandlerFactory` determines whether an event should be handled by the `QueueHandler` or `CliHandler`.

In a previous PR the behavior of the CliHandlerFactory was changed (https://github.com/laravel/vapor-core/pull/194). But we have previously relied on the queue handler being triggered for most of our custom events. While we tried to use the `vapor:handle {payload}` way, this resulted in execution times going to 400-600ms from the previous 20-40ms. Likely because the CliHandler does not respect Octane configurations and spawns a new process every time.

Changing how the CliHandler works so it does not spawn a new process every time would work too, but this seems risky as to not break existing workflows. This dynamic configuration of the CliHandlerFactory still allows custom payloads to be handled by the queue handler if the user wants it, without any risk on breaking anything.