### PR TITLE
fix: `curl_close()` is deprecated

### DIFF
--- a/src/Runtime/NotifiesLambda.php
+++ b/src/Runtime/NotifiesLambda.php
@@ -75,6 +75,10 @@ trait NotifiesLambda
 
         curl_reset($handler);
 
-        curl_close($handler);
+        if (PHP_VERSION_ID >= 80000) {
+            unset($handler);
+        } else {
+            curl_close($handler);
+        }
     }
 }


### PR DESCRIPTION
### PHP 8.5 `curl_close()` deprecation

`curl_close()` is deprecated as of **PHP 8.5** and has effectively been a no-op since **PHP 8.0** due to the resource to object conversion.

The current implementation is triggering deprecation warnings.


**References**

- [RFC](https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_no-op_functions_from_the_resource_to_object_conversion)

- [Commit](https://github.com/php/php-src/commit/9b13bb1ae45f2e8abf6a702b64fd2333a23fc341#diff-8e0f968fefdfb8e72b009bf61ac8660825f790f451c190b94ac6cdbb8d84a996)

- `curl_close()` marked as deprecated in the cURL stubs https://github.com/php/php-src/blob/b17b699c69f5c9e7ddf65bb35293e351f3f182b0/ext/curl/curl.stub.php#L3743-L3744

