### PR TITLE
[2.x] Fix test compatibility across Laravel 10-13 and PHPUnit 10-12

### DIFF
--- a/tests/Feature/EnsureOnNakedDomainTest.php
+++ b/tests/Feature/EnsureOnNakedDomainTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Route;
 use Laravel\Vapor\Runtime\Http\Middleware\EnsureOnNakedDomain;
 use Laravel\Vapor\VaporServiceProvider;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class EnsureOnNakedDomainTest extends TestCase
 {
@@ -27,9 +28,7 @@ class EnsureOnNakedDomainTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider useCases
-     */
+    #[DataProvider('useCases')]
     public function test_redirects($useCase)
     {
         config()->set('vapor.redirect_to_root', $useCase['redirect_to_root']);

--- a/tests/Feature/OctaneManageDatabaseSessionsTest.php
+++ b/tests/Feature/OctaneManageDatabaseSessionsTest.php
@@ -17,7 +17,7 @@ class OctaneManageDatabaseSessionsTest extends TestCase
                 'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away'
             ));
 
-        $this->assertDoesntThrow(function () use ($stalePdo) {
+        try {
             collect([$stalePdo])
                 ->filter(fn ($pdo) => $pdo instanceof PDO)
                 ->each(function ($pdo) {
@@ -27,7 +27,11 @@ class OctaneManageDatabaseSessionsTest extends TestCase
                         // Connection already gone away, safe to ignore...
                     }
                 });
-        });
+        } catch (\Throwable $e) {
+            $this->fail('Expected no exception, but caught: '.$e->getMessage());
+        }
+
+        $this->assertTrue(true);
     }
 
     public function test_it_proves_bug_exists_without_fix()
@@ -81,7 +85,7 @@ class OctaneManageDatabaseSessionsTest extends TestCase
                 'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away'
             ));
 
-        $this->assertDoesntThrow(function () use ($livePdo, $stalePdo) {
+        try {
             collect([$livePdo, $stalePdo])
                 ->filter(fn ($pdo) => $pdo instanceof PDO)
                 ->each(function ($pdo) {
@@ -91,6 +95,10 @@ class OctaneManageDatabaseSessionsTest extends TestCase
                         //
                     }
                 });
-        });
+        } catch (\Throwable $e) {
+            $this->fail('Expected no exception, but caught: '.$e->getMessage());
+        }
+
+        $this->assertTrue(true);
     }
 }

--- a/tests/Feature/VaporQueueTest.php
+++ b/tests/Feature/VaporQueueTest.php
@@ -42,11 +42,6 @@ class VaporQueueTest extends TestCase
                 'job' => 'Illuminate\Queue\CallQueuedHandler@call',
                 'maxTries' => null,
                 'timeout' => null,
-                'data' => [
-                    'commandName' => FakeJob::class,
-                    'command' => serialize($job),
-                    'batchId' => null,
-                ],
                 'attempts' => 0,
             ];
 
@@ -54,6 +49,10 @@ class VaporQueueTest extends TestCase
                 $this->assertArrayHasKey($key, $messageBody);
                 $this->assertSame($value, $messageBody[$key]);
             }
+
+            $this->assertArrayHasKey('data', $messageBody);
+            $this->assertSame(FakeJob::class, $messageBody['data']['commandName']);
+            $this->assertSame(serialize($job), $messageBody['data']['command']);
 
             return true;
         }))->andReturnSelf();

--- a/tests/Feature/VaporQueueTest.php
+++ b/tests/Feature/VaporQueueTest.php
@@ -45,6 +45,7 @@ class VaporQueueTest extends TestCase
                 'data' => [
                     'commandName' => FakeJob::class,
                     'command' => serialize($job),
+                    'batchId' => null,
                 ],
                 'attempts' => 0,
             ];

--- a/tests/Unit/VaporScheduleCommandTest.php
+++ b/tests/Unit/VaporScheduleCommandTest.php
@@ -44,6 +44,9 @@ class VaporScheduleCommandTest extends TestCase
             Cache::shouldReceive('driver')->once()->andReturn($fake);
         }
         $fake->shouldNotReceive('forget')->with('vapor:schedule:lock');
+        if (version_compare($this->app->version(), '13.0.0', '>=')) {
+            $fake->shouldReceive('get')->with('illuminate:schedule:paused', false)->andReturn(false);
+        }
 
         $this->artisan('vapor:schedule')
             ->assertExitCode(0);
@@ -58,6 +61,9 @@ class VaporScheduleCommandTest extends TestCase
             $fake->shouldReceive('forget')->once()->with('illuminate:schedule:interrupt')->andReturn(true);
         }
         $fake->shouldReceive('forget')->once()->with('vapor:schedule:lock')->andReturn(true);
+        if (version_compare($this->app->version(), '13.0.0', '>=')) {
+            $fake->shouldReceive('get')->with('illuminate:schedule:paused', false)->andReturn(false);
+        }
 
         $this->artisan('vapor:schedule')
             ->assertExitCode(0);


### PR DESCRIPTION
## Summary

Fixes all test failures on the `2.0` branch that have been consistently failing on scheduled CI runs. The branch has been red for at least 5 days across multiple matrices.

### Root causes

1. **Laravel 13.0 (2026-03-11)** shipped with **PHPUnit 12**, which dropped support for `@dataProvider` docblock annotations — only the `#[DataProvider]` PHP attribute works. This broke `EnsureOnNakedDomainTest`.

2. **Laravel 13.0** introduced a new **schedule pause feature** — `ScheduleRunCommand::handle()` now calls `isPaused()` at line 120, which reads `illuminate:schedule:paused` from cache. `VaporScheduleCommand` calls `schedule:run` internally, and the test mocks for the cache weren't expecting this new call. This broke `VaporScheduleCommandTest` on the L13 matrix.

3. **Laravel 12.51.0 (2026-02-10)** added `'batchId' => null` to the queue job payload in `Queue::createObjectPayload()` (commit `eef787a7`, "[12.x] Fix batch counts when deleteWhenMissingModels skips missing model jobs"). The `VaporQueueTest` used `assertSame` on the entire `data` sub-array, which failed due to the extra key. This affected **all** Laravel 12.51+ and 13.x matrices.

4. **PHPUnit 10.x** (used by Laravel 10/11) does not have `assertDoesntThrow()` — that method was added in PHPUnit 11.4. `OctaneManageDatabaseSessionsTest` used it unconditionally, breaking the L10 and L11 matrices. This is a pre-existing issue unrelated to L13.

### Changes

- **VaporQueueTest**: Assert `data` payload keys individually instead of comparing the entire sub-array with `assertSame`. This validates `commandName` and `command` have the correct values without breaking when the framework adds new keys like `batchId`.

- **VaporScheduleCommandTest**: Add cache mock expectation for `get('illuminate:schedule:paused', false)`, version-gated to `>= 13.0.0` so existing Laravel 10/11/12 tests are unaffected.

- **EnsureOnNakedDomainTest**: Replace `@dataProvider useCases` docblock with `#[DataProvider('useCases')]` PHP attribute for PHPUnit 12 compatibility.

- **OctaneManageDatabaseSessionsTest**: Replace `assertDoesntThrow()` with an equivalent try/catch + `$this->fail()` pattern that works across PHPUnit 10, 11, and 12.

## Test plan

- [x] All 144 tests pass locally on PHP 8.5 + Laravel 13.1.1 + PHPUnit 12.5.14
- [x] CI green on all 8 matrices: PHP 8.1–8.3 × Laravel 10–13
- [x] Static analysis passing
- [x] StyleCI passing