### PR TITLE
Skip VaporServiceProvider registration on Laravel Cloud

### DIFF
--- a/src/VaporServiceProvider.php
+++ b/src/VaporServiceProvider.php
@@ -29,6 +29,10 @@ class VaporServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if ($this->runningOnLaravelCloud()) {
+            return;
+        }
+
         $this->ensureRoutesAreDefined();
         $this->registerOctaneCommands();
 
@@ -66,6 +70,10 @@ class VaporServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        if ($this->runningOnLaravelCloud()) {
+            return;
+        }
+
         $this->app->singleton(
             Contracts\SignedStorageUrlController::class,
             SignedStorageUrlController::class
@@ -179,6 +187,20 @@ class VaporServiceProvider extends ServiceProvider
         });
 
         $this->commands(['command.vapor.work', 'command.vapor.queue-failed', 'command.vapor.health-check', 'command.vapor.schedule']);
+    }
+
+    /**
+     * Determine if the application is running on Laravel Cloud.
+     *
+     * @return bool
+     */
+    protected function runningOnLaravelCloud()
+    {
+        if (function_exists('laravel_cloud')) {
+            return laravel_cloud();
+        }
+
+        return (($_ENV['LARAVEL_CLOUD'] ?? $_SERVER['LARAVEL_CLOUD'] ?? null)) === '1';
     }
 
     /**


### PR DESCRIPTION
## Summary

Short-circuit `VaporServiceProvider::register()` and `::boot()` when the
application is running on Laravel Cloud, so that `vapor-core` doesn't
register anything — most importantly, doesn't replace the framework's
SQS queue connector via `Queue::extend('sqs', …)`.

## The problem this fixes

Laravel Cloud and Vapor are mutually exclusive runtimes, but some Cloud
apps still have \`laravel/vapor-core\` installed (typically a leftover
from a Vapor → Cloud migration). On Cloud, \`VaporServiceProvider::boot\`
still fires:

\`\`\`php
Queue::extend('sqs', function () {
    return new VaporConnector;
});
\`\`\`

\`VaporConnector::connect()\` only understands static \`key\`/\`secret\`
credentials and silently ignores the \`credentials\` config key
(laravel/framework#59733 introduced support for named credential
providers on the framework \`SqsConnector\`, and
\`Illuminate\Foundation\Cloud::configureManagedQueues()\` sets
\`queue.connections.sqs.credentials = 'ecs'\` when
\`LARAVEL_CLOUD_MANAGED_QUEUES=1\`).

Because Vapor's \`extend\` runs *after* framework providers boot and is
last-write-wins, the framework \`SqsConnector\` is replaced, the managed
\`credentials => 'ecs'\` config is never honored, the fallback
\`if (! empty(\$config['key']) && ! empty(\$config['secret']))\` branch
wins, and SQS requests end up signed with whatever
\`AWS_ACCESS_KEY_ID\` / \`AWS_SECRET_ACCESS_KEY\` the app has in its env
instead of the EKS Pod Identity role. Observable symptom: an
\`AccessDenied\` error naming the static IAM user ARN, not the expected
\`arn:aws:sts::…:assumed-role/…\`.

## The fix

Early-return from \`register()\` and \`boot()\` when the app is running on
Laravel Cloud. Nothing inside Vapor's provider is useful on Cloud:

- Every \`Configures*\` trait is already gated on \`VAPOR_SSM_PATH\` /
  \`VAPOR_CACHE\` / \`VAPOR_SERVERLESS_DB\`, none of which are set on
  Cloud — those are already no-ops.
- The always-on bits (\`SignedStorageUrlController\` singleton,
  \`configureTrustedProxy\`, the \`ServeStaticAssets\` middleware, Vapor's
  console commands, the sqs queue extension) have no business running
  on Cloud.

Detection prefers the canonical \`laravel_cloud()\` helper when
available, and falls back to an inline \`\$_ENV\` / \`\$_SERVER\` check on
legacy Laravel versions that predate the helper. This means the
existing composer constraint (\`illuminate/support: ^6.0|^7.0|…\`) does
not need to change.

## No breaking changes

This only changes behavior when the app is running on Laravel Cloud, a
context where Vapor's provider is never supposed to be doing anything
anyway. Off-Cloud behavior (Vapor, local, CI) is untouched and all
existing tests remain green.