### PR TITLE
Allow Symfony 8 components for Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "monolog/monolog": "^1.12|^2.0|^3.2",
         "nyholm/psr7": "^1.0",
         "riverline/multipart-parser": "^2.0.9",
-        "symfony/process": "^4.3|^5.0|^6.0|^7.0",
-        "symfony/psr-http-message-bridge": "^1.0|^2.0|^6.4|^7.0"
+        "symfony/process": "^4.3|^5.0|^6.0|^7.0|^8.0",
+        "symfony/psr-http-message-bridge": "^1.0|^2.0|^6.4|^7.0|^8.0"
     },
     "require-dev": {
         "laravel/octane": "*",


### PR DESCRIPTION
v2.43.4 widened the `illuminate/*` constraints to `^13.0`, but `symfony/process` and `symfony/psr-http-message-bridge` still cap at `^7.0`. Laravel 13 ships Symfony 8 components, so vapor-core can't actually install on a fresh L13 project `composer require laravel/vapor-core` fails with:                         
                                                                                                                      
  laravel/vapor-core[..., v2.43.4] require symfony/process ^4.3|^5.0|^6.0|^7.0  but the package is fixed to v8.0.8 (lock file version)

This PR widens both constraints to include `^8.0`, completing the L13 support work started in #201. 

Unit tests OK
<img width="951" height="303" alt="image" src="https://github.com/user-attachments/assets/1d38dbbe-3f7a-4b43-8199-c15fa80a9a11" />


Tested locally I can require laravel/vapor-core
<img width="1313" height="849" alt="image" src="https://github.com/user-attachments/assets/5537ed86-46c0-43c3-be30-d179fb55c897" />
