### PR TITLE
fix(api-gateway): handle multi-value cookies correctly

### DIFF
--- a/src/Runtime/Request.php
+++ b/src/Runtime/Request.php
@@ -186,6 +186,10 @@ class Request
         return array_change_key_case(
             collect($event['multiValueHeaders'] ?? [])
                 ->mapWithKeys(function ($headers, $name) {
+                    if (strtolower($name) === 'cookie') {
+                        return [$name => implode('; ', $headers)];
+                    }
+
                     return [$name => Arr::last($headers)];
                 })->all(), CASE_LOWER
         );

--- a/tests/Feature/ApiGatewayOctaneHandlerTest.php
+++ b/tests/Feature/ApiGatewayOctaneHandlerTest.php
@@ -356,6 +356,34 @@ EOF
         );
     }
 
+    public function test_request_cookies_from_multi_value_headers()
+    {
+        $handler = new OctaneHandler();
+
+        Route::get('/', function (Request $request) {
+            return $request->cookies->all();
+        });
+
+        $response = $handler->handle([
+            'httpMethod' => 'GET',
+            'path' => '/',
+            'headers' => [
+                'cookie' => 'cookie_b=def',
+            ],
+            'multiValueHeaders' => [
+                'cookie' => [
+                    'cookie_a=abc',
+                    'cookie_b=def',
+                ],
+            ],
+        ]);
+
+        static::assertEquals(
+            ['cookie_a' => 'abc', 'cookie_b' => 'def'],
+            json_decode($response->toApiGatewayFormat()['body'], true)
+        );
+    }
+
     public function test_request_file_uploads()
     {
         $handler = new OctaneHandler();

--- a/tests/Unit/FpmRequestTest.php
+++ b/tests/Unit/FpmRequestTest.php
@@ -227,4 +227,70 @@ class FpmRequestTest extends TestCase
 
         $this->assertArrayNotHasKey('AWS_API_GATEWAY_REQUEST_TIME', $request->serverVariables);
     }
+
+    public function test_multi_value_cookie_header_preserves_all_cookies()
+    {
+        $request = FpmRequest::fromLambdaEvent([
+            'httpMethod' => 'GET',
+            'multiValueHeaders' => [
+                'Cookie' => [
+                    'cookie_a=abc',
+                    'cookie_b=def',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('cookie_a=abc; cookie_b=def', $request->serverVariables['HTTP_COOKIE']);
+    }
+
+    public function test_api_gateway_rest_modern_tls_payload_preserves_all_cookies()
+    {
+        $request = FpmRequest::fromLambdaEvent([
+            'resource' => '/{proxy+}',
+            'path' => '/api/shared/auth/who-am-i-cookie',
+            'httpMethod' => 'GET',
+            'headers' => [
+                'cookie' => 'cookie_b=refresh-value',
+            ],
+            'multiValueHeaders' => [
+                'cookie' => [
+                    'cookie_a=access-value',
+                    'cookie_b=refresh-value',
+                ],
+            ],
+            'requestContext' => [
+                'protocol' => 'HTTP/1.1',
+            ],
+        ]);
+
+        $this->assertSame(
+            'cookie_a=access-value; cookie_b=refresh-value',
+            $request->serverVariables['HTTP_COOKIE']
+        );
+    }
+
+    public function test_api_gateway_rest_legacy_tls_payload_preserves_all_cookies()
+    {
+        $request = FpmRequest::fromLambdaEvent([
+            'resource' => '/{proxy+}',
+            'path' => '/api/shared/auth/who-am-i-cookie',
+            'httpMethod' => 'GET',
+            'headers' => [
+                'cookie' => 'cookie_a=access-value; cookie_b=refresh-value',
+            ],
+            'multiValueHeaders' => [
+                'cookie' => [
+                    'cookie_a=access-value; cookie_b=refresh-value',
+                ],
+            ],
+            'requestContext' => [
+                'protocol' => 'HTTP/1.1',
+            ],
+        ]);
+
+        $this->assertSame(
+            'cookie_a=access-value; cookie_b=refresh-value',
+            $request->serverVariables['HTTP_COOKIE']
+        );
+    }
 }


### PR DESCRIPTION
When AWS API Gateway REST runs a modern TLS security policy, the `Cookie` header arrives as a multi-element array under `multiValueHeaders.cookie` (one entry per cookie-pair), while the flat `headers.cookie` field collapses to the last entry only. `Request::getHeaders()` calls `Arr::last()` on every multi-value header, so all cookies except the last are silently dropped before `HTTP_COOKIE` is built, both FPM `$_COOKIE` and Symfony's `$request->cookies` bag lose them.

We hit this in staging environments right after upgrading our gateway's TLS policy: `access_token` (sent first) arrived as `null`, `refresh_token` (sent second) survived, breaking session resumption.

## Evidence
Real CloudWatch payloads (cookie values excluded):

**Broken (modern TLS):**
```json
"headers":           { "cookie": "refresh_token=…" },
"multiValueHeaders": { "cookie": ["access_token=…", "refresh_token=…"] }
```

**Working (legacy TLS):**
```json
"headers":           { "cookie": "access_token=…; refresh_token=…" },
"multiValueHeaders": { "cookie": ["access_token=…; refresh_token=…"] }
```

requestContext.protocol reports HTTP/1.1 in both, so the wire protocol isn't directly observable. Most likely upstream cause is browsers negotiating HTTP/2 with the gateway once modern ciphers enable ALPN h2, splitting per RFC 7540 §8.1.2.5 (https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.5).

## Fix
In getHeaders(), special-case the cookie header to join multiple values with "; ". Other multi-value headers keep Arr::last(), important for ELB anti-spoofing (test_load_balancer_headers_are_over_spoofed_headers).